### PR TITLE
fix(status): fold skill model alias to canonical in masked/override hashes

### DIFF
--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -7324,7 +7324,14 @@ function transformedSkillContentHash(path, from, to) {
     const absolute = join(path, raw);
     const canonical = readSkillFileForHash(path, raw);
     const content = isTextMappingFile(absolute)
-      ? transformTextForHost(canonical.toString("utf8"), from, to)
+      ? Buffer.from(
+          normalizeSkillFileText(
+            transformTextForHost(canonical.toString("utf8"), from, to),
+            raw,
+            absolute
+          ),
+          "utf8"
+        )
       : canonical;
     hash.update(normalized);
     hash.update(content);

--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -7352,7 +7352,11 @@ function maskedSkillContentHash(path, sourceHost, targetHost, terms) {
       const text =
         sourceHost === targetHost
           ? canonical.toString("utf8")
-          : transformTextForHost(canonical.toString("utf8"), sourceHost, targetHost);
+          : normalizeSkillFileText(
+              transformTextForHost(canonical.toString("utf8"), sourceHost, targetHost),
+              raw,
+              absolute
+            );
       content = Buffer.from(maskLinesContaining(text, terms), "utf8");
     } else {
       content = canonical;
@@ -7398,7 +7402,14 @@ function overriddenTransformedSkillContentHash(path, sourceHost, targetHost, ove
     const absolute = join(path, raw);
     const masked = readSkillFileMaskedForHash(path, raw, sourceHost, overrides);
     const content = isTextMappingFile(absolute)
-      ? Buffer.from(transformTextForHost(masked.toString("utf8"), sourceHost, targetHost), "utf8")
+      ? Buffer.from(
+          normalizeSkillFileText(
+            transformTextForHost(masked.toString("utf8"), sourceHost, targetHost),
+            raw,
+            absolute
+          ),
+          "utf8"
+        )
       : masked;
     hash.update(normalized);
     hash.update(content);

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -970,6 +970,7 @@ test("status treats skill differing by model alias plus an override-masked line 
   );
   assert.equal(report.entries.length, 0);
   assert.equal(report.paraphraseOverrides.active.length, 1);
+  assert.equal(report.paraphraseOverrides.stale.length, 0);
 });
 
 test("status preview shows diff in references/* file when manifest is masked", () => {

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -884,6 +884,94 @@ test("status treats skill differing only by model alias as equivalent (no phanto
   assert.equal(report.entries.length, 0);
 });
 
+test("status treats skill differing by model alias plus a term-masked line as equivalent", () => {
+  // Regression for #10 sibling path: maskedSkillContentHash transforms to the
+  // host-native model alias but never folds it back to canonical the way
+  // skillContentHash does. When a skill needs BOTH a term ignore rule (to mask a
+  // diverging prose line) AND the model fold, the masked hash ends on gpt-5.5 vs
+  // canonical opus and the skill surfaces as a phantom manual conflict.
+  const fixture = createFixture();
+  writeSkillManifest(
+    join(fixture.project, ".claude/skills/masked-alias"),
+    "claude",
+    [
+      "---",
+      "name: masked-alias",
+      "model: Opus",
+      "---",
+      "# X",
+      "refs .claude/docs/repo-analysis/ here",
+      "common line",
+      "",
+    ].join("\n")
+  );
+  writeSkillManifest(
+    join(fixture.project, ".agents/skills/masked-alias"),
+    "codex",
+    ["---", "name: masked-alias", "model: gpt-5.5", "---", "# X", "common line", ""].join("\n")
+  );
+  mkdirSync(join(fixture.project, ".ai-config-sync-manager"), { recursive: true });
+  writeJson(join(fixture.project, ".ai-config-sync-manager/status-ignore.json"), {
+    version: 1,
+    exclude: [{ area: "skills", term: ".claude/docs/repo-analysis/" }],
+  });
+
+  const report = JSON.parse(
+    runCli(fixture, ["status", "--scope", "project", "--include", "skills:masked-alias", "--json"])
+  );
+  assert.equal(report.entries.length, 0);
+});
+
+test("status treats skill differing by model alias plus an override-masked line as equivalent", () => {
+  // Regression for #10 sibling path: overriddenTransformedSkillContentHash layers
+  // transformTextForHost over paraphrase masking but never folds the model token
+  // back to canonical. A skill needing BOTH a paraphrase override (to mask a
+  // diverging prose line) AND the model fold ends on gpt-5.5 vs canonical opus,
+  // surfacing as a phantom manual conflict even though the prose is overridden.
+  const fixture = createFixture();
+  const projectReal = realpathSync(fixture.project);
+  const claudeSkill = join(projectReal, ".claude/skills/override-alias");
+  const codexSkill = join(projectReal, ".agents/skills/override-alias");
+  mkdirSync(claudeSkill, { recursive: true });
+  mkdirSync(codexSkill, { recursive: true });
+  writeFileSync(
+    join(claudeSkill, "SKILL.md"),
+    "---\nname: override-alias\nmodel: Opus\n---\n# X\nRead the docs.\n"
+  );
+  writeFileSync(
+    join(codexSkill, "SKILL.md"),
+    "---\nname: override-alias\nmodel: gpt-5.5\n---\n# X\nInspect the docs.\n"
+  );
+  writeJson(join(fixture.home, ".ai-config-sync-manager/rules/paraphrase-overrides.json"), {
+    version: 1,
+    overrides: [
+      {
+        id: "override-alias-line6",
+        area: "skills",
+        claude_path: join(claudeSkill, "SKILL.md"),
+        codex_path: join(codexSkill, "SKILL.md"),
+        claude_line: 6,
+        codex_line: 6,
+        claude_text: "Read the docs.",
+        codex_text: "Inspect the docs.",
+      },
+    ],
+  });
+
+  const report = JSON.parse(
+    runCli(fixture, [
+      "status",
+      "--scope",
+      "project",
+      "--include",
+      "skills:override-alias",
+      "--json",
+    ])
+  );
+  assert.equal(report.entries.length, 0);
+  assert.equal(report.paraphraseOverrides.active.length, 1);
+});
+
 test("status preview shows diff in references/* file when manifest is masked", () => {
   // Verifies skillDirChangePreview iterates beyond SKILL.md so a real diff in
   // references/foo.md becomes visible even when the manifest is fully masked

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -858,6 +858,32 @@ test("status treats skill as equivalent when transform and override jointly equa
   assert.equal(report.paraphraseOverrides.stale.length, 0);
 });
 
+test("status treats skill differing only by model alias as equivalent (no phantom conflict)", () => {
+  // Regression for the status equivalence path: transformedSkillContentHash must
+  // fold the transformed model token back to canonical (like skillContentHash),
+  // otherwise the forward (claude->codex) hash ends on a host-native value and
+  // surfaces a manual-risk phantom conflict even though copy/preview already
+  // report equivalence. Claude's "Opus" is a tier *term*, not the alias, so the
+  // alias-keyed normalizeModelAlias leaves it unfolded on read — only the
+  // post-transform normalize closes the gap.
+  const fixture = createFixture();
+  mkdirSync(join(fixture.project, ".claude/skills/aliased"), { recursive: true });
+  mkdirSync(join(fixture.project, ".agents/skills/aliased"), { recursive: true });
+  writeFileSync(
+    join(fixture.project, ".claude/skills/aliased/SKILL.md"),
+    "---\nname: aliased\nmodel: Opus\n---\n# Aliased\nShared body.\n"
+  );
+  writeFileSync(
+    join(fixture.project, ".agents/skills/aliased/SKILL.md"),
+    "---\nname: aliased\nmodel: gpt-5.5\n---\n# Aliased\nShared body.\n"
+  );
+
+  const report = JSON.parse(
+    runCli(fixture, ["status", "--scope", "project", "--include", "skills:aliased", "--json"])
+  );
+  assert.equal(report.entries.length, 0);
+});
+
 test("status preview shows diff in references/* file when manifest is masked", () => {
   // Verifies skillDirChangePreview iterates beyond SKILL.md so a real diff in
   // references/foo.md becomes visible even when the manifest is fully masked


### PR DESCRIPTION
## What

Closes the remaining **phantom manual-risk conflicts** in `status` caused by skill model-alias differences, following up #10.

`skillContentHash` normalizes every skill manifest to the canonical (claude) model alias on read. But the sibling equivalence hashes applied `transformTextForHost` **without** folding the model token back to canonical, so a skill differing only by a model alias hashed differently and surfaced as a manual-risk conflict in `status` — even though the copy and preview paths already treat the two as equivalent.

## Fix

Run post-transform text back through `normalizeSkillFileText` so the forward hash folds to the same canonical form as `skillContentHash`:

- `e78bf0d` — `transformedSkillContentHash` (forward claude→codex equivalence).
- `9855663` — `maskedSkillContentHash` (term ignore rules) and `overriddenTransformedSkillContentHash` (paraphrase overrides). #10 patched only the transformed path; a skill needing both masking AND the model fold still surfaced as phantom.

The gap was reachable because `normalizeModelAlias` is alias-keyed: a tier *term* like "Opus" stays unfolded on read and is only closed by the post-transform normalize.

## Tests

`npm test` → **288 pass / 0 fail**. Adds fixture coverage in `tests/cli-fixtures.test.mjs` for the masked + override + model-fold combination.

Follow-up to #10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill file equivalence detection across different hosts to ensure proper content normalization when comparing files.
  * Fixed status diffing logic to correctly identify equivalent configurations when model aliases differ, eliminating false conflict reports.

* **Tests**
  * Added regression tests to verify status diffing handles model alias variations and their combinations with other configuration masks correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->