### PR TITLE
fix(sync): preserve .claude/rules paths instead of rewriting to .codex/rules (#15)

### DIFF
--- a/rules/terminology-map.json
+++ b/rules/terminology-map.json
@@ -64,10 +64,10 @@
         },
         {
           "id": "claude-codex-prefix",
-          "description": "Generic catchall for any .claude/<rest> directory reference. Listed last in this layer so the more specific rules above (agent-file-path with .md<->.toml, skill-file-path with .claude/skills <-> .agents/skills, skill-manifest-filename) match first; this rule then catches everything else (.claude/docs, .claude/hooks, .claude/insights, .claude/insight, .claude/plugins, etc.) with a plain prefix swap to .codex/<rest>. Negative lookaheads carve out the literal exception files handled by the literal rules above (settings.json/mcp.json on the Claude side, config.toml on the Codex side) so those keep their precise filename mapping (settings.json <-> config.toml, mcp.json <-> config.toml [mcp_servers]) instead of getting a partial prefix-only swap.",
+          "description": "Generic catchall for any .claude/<rest> directory reference. Listed last in this layer so the more specific rules above (agent-file-path with .md<->.toml, skill-file-path with .claude/skills <-> .agents/skills, skill-manifest-filename) match first; this rule then catches everything else (.claude/docs, .claude/hooks, .claude/insights, .claude/insight, .claude/plugins, etc.) with a plain prefix swap to .codex/<rest>. Negative lookaheads carve out the literal exception files handled by the literal rules above (settings.json/mcp.json on the Claude side, config.toml on the Codex side) so those keep their precise filename mapping (settings.json <-> config.toml, mcp.json <-> config.toml [mcp_servers]) instead of getting a partial prefix-only swap. rules is also carved out both ways because .claude/rules (path-scoped guidance docs) and .codex/rules (prefix_rule command-approval policy) are unrelated concepts and must not share a target path.",
           "regex": true,
-          "claude_pattern": "\\.claude/(?!settings\\.json\\b|mcp\\.json\\b)",
-          "codex_pattern": "\\.codex/(?!config\\.toml\\b)",
+          "claude_pattern": "\\.claude/(?!settings\\.json\\b|mcp\\.json\\b|rules\\b)",
+          "codex_pattern": "\\.codex/(?!config\\.toml\\b|rules\\b)",
           "claude_replace": ".claude/",
           "codex_replace": ".codex/"
         }

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -3592,6 +3592,30 @@ test("sync apply preserves precise settings.json / mcp.json / config.toml mappin
   assert.doesNotMatch(codexBody, /\.claude\//);
 });
 
+test("sync apply preserves .claude/rules guidance paths instead of rewriting them to .codex/rules", () => {
+  const fixture = createFixture();
+  writeSkillManifest(
+    join(fixture.project, ".claude/skills/rules-carveout"),
+    "claude",
+    [
+      "# Rules Carveout",
+      "Path scoped rules live under `.claude/rules/go.md`.",
+      "Non-segment match `.claude/rulesfoo/bar.md` is still swapped.",
+      "",
+    ].join("\n")
+  );
+
+  runCli(fixture, ["sync", "--scope", "project", "--include", "skills:rules-carveout", "--apply"]);
+  const codexBody = readFileSync(
+    join(fixture.project, ".agents/skills/rules-carveout/SKILL.md"),
+    "utf8"
+  );
+
+  assert.match(codexBody, /\.claude\/rules\/go\.md/);
+  assert.doesNotMatch(codexBody, /\.codex\/rules\/go\.md/);
+  assert.match(codexBody, /\.codex\/rulesfoo\/bar\.md/);
+});
+
 test("sync apply rewrites prose mentions of TeamCreate to multiple spawn_agent invocations on Codex side", () => {
   const fixture = createFixture();
   writeSkillManifest(


### PR DESCRIPTION
Closes #15.

## Problem

The generic `claude-codex-prefix` catchall in `rules/terminology-map.json` blindly swapped any `.claude/<rest>` prefix to `.codex/<rest>`. That turned `.claude/rules/<file>` (path-scoped guidance docs Claude Code loads by file match, `paths:` frontmatter) into `.codex/rules/<file>` (Codex `prefix_rule` command-approval policy) — unrelated concepts. The synced `AGENTS.md` then pointed at non-existent files and clashed with the documented meaning of `.codex/rules`. Status reported "no diff" because the map treated the rewrite as equivalent, hiding the bug.

## Fix

Carve `rules` out of the catchall in **both directions**, reusing the existing negative-lookahead pattern that already protects `settings.json` / `mcp.json` / `config.toml`:

```diff
- "claude_pattern": "\\.claude/(?!settings\\.json\\b|mcp\\.json\\b)",
- "codex_pattern": "\\.codex/(?!config\\.toml\\b)",
+ "claude_pattern": "\\.claude/(?!settings\\.json\\b|mcp\\.json\\b|rules\\b)",
+ "codex_pattern": "\\.codex/(?!config\\.toml\\b|rules\\b)",
```

- `.claude/rules/...` preserved on `CLAUDE.md` → `AGENTS.md`.
- Reverse carved too: genuine `.codex/rules` (approval policy) no longer rewritten to `.claude/rules`.
- `\b` keeps it precise — `.claude/rules/go.md` preserved, `.claude/rulesfoo/...` still falls through to the generic swap.

Chose the terminology exception (issue option 1) over a status-ignore entry: an ignore rule only hides the status item, while the broken text would still be written on `sync --apply`. The defect is in the transform.

## Test

New regression test in `tests/cli-fixtures.test.mjs` reproducing the exact case (`.claude/rules/go.md` preserved, no `.codex/rules/go.md`, non-exact segment still swapped). Full suite: **289 pass / 0 fail**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path transformation logic to correctly preserve guidance rule paths from being rewritten during synchronization operations, ensuring nested rule configurations remain intact.

* **Tests**
  * Added test coverage verifying that guidance rule paths are properly preserved during sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->