### PR TITLE
ci(upstream-compat): extend nested allowlist scan + add Layer 3 host roundtrip

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -430,7 +430,6 @@ jobs:
           fi
 
       - name: Open drift PR
-        id: create-pr
         if: steps.drift.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -442,43 +441,3 @@ jobs:
           commit-message: "chore(snapshots): refresh upstream snapshots"
           labels: compatibility
           add-paths: snapshots
-
-      - name: LLM compat review (Layer 2/4)
-        # secrets context is unavailable in step if; gate on env instead so the step no-ops when the key is unset.
-        if: steps.create-pr.outputs.pull-request-number != '' && env.ANTHROPIC_API_KEY != ''
-        continue-on-error: true
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          set -euo pipefail
-          npm install -g @anthropic-ai/claude-code
-          mkdir -p .upstream-compat
-          PROMPT=$(cat <<'EOF'
-          You are reviewing an automated upstream compatibility drift PR for AI Config Sync Manager (a Claude/Codex config sync CLI). Work read-only.
-
-          Layer 2 — coverage mapping:
-          Read the "Compat scan" section of .upstream-compat/body.md and collect every uncovered upstream key it lists. For each key, read its description from snapshots/codex/config-schema.json and snapshots/claude/settings-schema.json, then search the opposite host's schema and the rules/*.json files for an equivalent concept. Emit a verdict table with columns: key | opposite-host concept | verdict (map / drop) | target (which rules file + mapping, or "register in rules/upstream-known-unsupported.json").
-
-          Layer 4 — manual review checklist:
-          Judge each item in the PR's Manual review checklist (Layer 4) against the snapshot diff, marking each pass / fail / needs-human with a one-line reason.
-
-          Output GitHub-comment markdown only. No preamble.
-          EOF
-          )
-          claude -p "$PROMPT" --allowedTools "Read,Grep,Glob" > .upstream-compat/llm-review.md
-          MARKER='<!-- llm-compat-review -->'
-          {
-            echo "$MARKER"
-            echo "> LLM-generated Layer 2/4 review — human approval still required."
-            echo
-            cat .upstream-compat/llm-review.md
-          } > .upstream-compat/llm-comment.md
-          PR="${{ steps.create-pr.outputs.pull-request-number }}"
-          # Reuse this run's own comment across weekly cron re-runs while the drift PR stays open, instead of stacking a new one each time.
-          existing=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
-            --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].id // empty")
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing" -F body=@.upstream-compat/llm-comment.md >/dev/null
-          else
-            gh pr comment "$PR" --body-file .upstream-compat/llm-comment.md
-          fi

--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -420,6 +420,7 @@ jobs:
           fi
 
       - name: Open drift PR
+        id: create-pr
         if: steps.drift.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -431,3 +432,33 @@ jobs:
           commit-message: "chore(snapshots): refresh upstream snapshots"
           labels: compatibility
           add-paths: snapshots
+
+      - name: LLM compat review (Layer 2/4)
+        # secrets context is unavailable in step if; gate on env instead so the step no-ops when the key is unset.
+        if: steps.create-pr.outputs.pull-request-number != '' && env.ANTHROPIC_API_KEY != ''
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          npm install -g @anthropic-ai/claude-code
+          mkdir -p .upstream-compat
+          PROMPT=$(cat <<'EOF'
+          You are reviewing an automated upstream compatibility drift PR for AI Config Sync Manager (a Claude/Codex config sync CLI). Work read-only.
+
+          Layer 2 — coverage mapping:
+          Read the "Compat scan" section of .upstream-compat/body.md and collect every uncovered upstream key it lists. For each key, read its description from snapshots/codex/config-schema.json and snapshots/claude/settings-schema.json, then search the opposite host's schema and the rules/*.json files for an equivalent concept. Emit a verdict table with columns: key | opposite-host concept | verdict (map / drop) | target (which rules file + mapping, or "register in rules/upstream-known-unsupported.json").
+
+          Layer 4 — manual review checklist:
+          Judge each item in the PR's Manual review checklist (Layer 4) against the snapshot diff, marking each pass / fail / needs-human with a one-line reason.
+
+          Output GitHub-comment markdown only. No preamble.
+          EOF
+          )
+          claude -p "$PROMPT" --allowedTools "Read,Grep,Glob" > .upstream-compat/llm-review.md
+          {
+            echo "> LLM-generated Layer 2/4 review — human approval still required."
+            echo
+            cat .upstream-compat/llm-review.md
+          } > .upstream-compat/llm-comment.md
+          gh pr comment "${{ steps.create-pr.outputs.pull-request-number }}" --body-file .upstream-compat/llm-comment.md

--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -441,3 +441,64 @@ jobs:
           commit-message: "chore(snapshots): refresh upstream snapshots"
           labels: compatibility
           add-paths: snapshots
+
+  roundtrip:
+    name: Layer 3 host behavior roundtrip
+    runs-on: ubuntu-latest
+    # Independent of snapshot — behavior can drift with no schema diff, so this must run even when snapshot is green.
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Claude Code and Codex CLIs
+        run: npm install -g @anthropic-ai/claude-code @openai/codex
+
+      - name: Run roundtrip compatibility test
+        id: roundtrip
+        run: |
+          set -o pipefail
+          mkdir -p .upstream-compat
+          node --test tests/upstream-compat/roundtrip.test.mjs 2>&1 | tee .upstream-compat/roundtrip.log
+
+      # Scoped to the test's own outcome so infra failures (npm ci, global install) don't file a "host drift" issue.
+      - name: Report host behavior drift
+        if: failure() && steps.roundtrip.outcome == 'failure'
+        run: |
+          set -euo pipefail
+          TITLE="Upstream host behavior drift detected (roundtrip failure)"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          {
+            echo "Layer 3 roundtrip compatibility test failed — a host CLI (Claude/Codex) behavior may have drifted without any schema diff."
+            echo
+            echo "Run: ${RUN_URL}"
+            echo
+            echo "Layer 3 — see .claude/docs/upstream-compat-plan.md"
+            echo
+            echo "## Test output (tail)"
+            echo
+            echo '```'
+            tail -c 4000 .upstream-compat/roundtrip.log 2>/dev/null || echo "(no test output captured)"
+            echo '```'
+          } > .upstream-compat/report.md
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file .upstream-compat/report.md
+          else
+            gh issue create --title "$TITLE" --label compatibility --body-file .upstream-compat/report.md
+          fi

--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -307,6 +307,16 @@ jobs:
                   current=$(hash_desc "$desc")
                   [ "$current" != "$recorded" ] && printf -- "- %s (%s → %s)\n" "$key" "$recorded" "$current"
                 done
+            # nested keys are "<Type>.<field>"; description lives under definitions.<Type>.properties.<field>.
+            jq -r ".${side}_nested // {} | to_entries[] | \"\(.key)\t\(.value.schema_desc_hash // \"\")\"" "$ALLOWLIST" \
+              | while IFS=$'\t' read -r key recorded; do
+                  [ -z "${key:-}" ] && continue
+                  type="${key%%.*}"; field="${key#*.}"
+                  desc=$(jq -r ".definitions.\"$type\".properties.\"$field\".description // \"\"" "$file" 2>/dev/null)
+                  [ -z "$desc" ] && continue
+                  current=$(hash_desc "$desc")
+                  [ "$current" != "$recorded" ] && printf -- "- %s (%s → %s)\n" "$key" "$recorded" "$current"
+                done
           }
           claude_hash_drift=$(hash_drift_section claude snapshots/claude/settings-schema.json || true)
           codex_hash_drift=$(hash_drift_section codex snapshots/codex/config-schema.json || true)
@@ -331,7 +341,7 @@ jobs:
           recheck_due_section() {
             local side="$1"
             [ -f "$ALLOWLIST" ] || return 0
-            jq -r --arg today "$today" ".${side}_top_level // {} | to_entries[] | select((.value.recheck_after // \"9999-12-31\") <= \$today) | \"- \(.key) (decided \(.value.decided_at // \"?\"), due \(.value.recheck_after // \"?\"))\"" "$ALLOWLIST" 2>/dev/null
+            jq -r --arg today "$today" "((.${side}_top_level // {}) + (.${side}_nested // {})) | to_entries[] | select((.value.recheck_after // \"9999-12-31\") <= \$today) | \"- \(.key) (decided \(.value.decided_at // \"?\"), due \(.value.recheck_after // \"?\"))\"" "$ALLOWLIST" 2>/dev/null
           }
           claude_recheck=$(recheck_due_section claude || true)
           codex_recheck=$(recheck_due_section codex || true)
@@ -456,9 +466,19 @@ jobs:
           EOF
           )
           claude -p "$PROMPT" --allowedTools "Read,Grep,Glob" > .upstream-compat/llm-review.md
+          MARKER='<!-- llm-compat-review -->'
           {
+            echo "$MARKER"
             echo "> LLM-generated Layer 2/4 review — human approval still required."
             echo
             cat .upstream-compat/llm-review.md
           } > .upstream-compat/llm-comment.md
-          gh pr comment "${{ steps.create-pr.outputs.pull-request-number }}" --body-file .upstream-compat/llm-comment.md
+          PR="${{ steps.create-pr.outputs.pull-request-number }}"
+          # Reuse this run's own comment across weekly cron re-runs while the drift PR stays open, instead of stacking a new one each time.
+          existing=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+            --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].id // empty")
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing" -F body=@.upstream-compat/llm-comment.md >/dev/null
+          else
+            gh pr comment "$PR" --body-file .upstream-compat/llm-comment.md
+          fi

--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -455,6 +455,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          # This job only reads the repo and calls gh via GH_TOKEN — no git push, so drop the stored push credential.
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ _workspace/
 !tests/integration/fixtures/**/.claude/
 !tests/integration/fixtures/**/.codex/
 !tests/integration/fixtures/**/.agents/
+!tests/upstream-compat/**/.claude/
+!tests/upstream-compat/**/.codex/
 !tests/integration/manual-codex-to-claude/**/.claude/
 !tests/integration/manual-codex-to-claude/**/.codex/
 !tests/integration/manual-codex-to-claude/**/.agents/

--- a/tests/upstream-compat/claude-fixtures/.claude.json
+++ b/tests/upstream-compat/claude-fixtures/.claude.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "notion": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["-e", "process.exit(0)"]
+    }
+  }
+}

--- a/tests/upstream-compat/claude-fixtures/.claude/agents/sample.md
+++ b/tests/upstream-compat/claude-fixtures/.claude/agents/sample.md
@@ -1,0 +1,6 @@
+---
+name: sample
+description: Translates user text to the requested target language.
+---
+
+Translate the user input verbatim and respond with only the translation.

--- a/tests/upstream-compat/claude-fixtures/.claude/settings.json
+++ b/tests/upstream-compat/claude-fixtures/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": ["Edit", "MultiEdit", "WebSearch", "Write"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo Pre"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ]
+  }
+}

--- a/tests/upstream-compat/claude-fixtures/.claude/skills/sample/SKILL.md
+++ b/tests/upstream-compat/claude-fixtures/.claude/skills/sample/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: sample
+description: Greets the user politely.
+---
+
+# Hello Skill
+
+Use this skill when the user greets the assistant.

--- a/tests/upstream-compat/codex-fixtures/.codex/agents/sample.toml
+++ b/tests/upstream-compat/codex-fixtures/.codex/agents/sample.toml
@@ -1,0 +1,3 @@
+name = "sample"
+description = "Translates user text to the requested target language."
+developer_instructions = "Translate the user input verbatim and respond with only the translation.\n"

--- a/tests/upstream-compat/codex-fixtures/.codex/config.toml
+++ b/tests/upstream-compat/codex-fixtures/.codex/config.toml
@@ -1,0 +1,16 @@
+sandbox_mode = "workspace-write"
+web_search = "live"
+
+[mcp_servers.notion]
+command = "npx"
+args = ["-y", "@notionhq/notion-mcp-server"]
+
+[features]
+hooks = true
+
+[[hooks.PreToolUse]]
+matcher = "Bash"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "echo Pre"

--- a/tests/upstream-compat/roundtrip.test.mjs
+++ b/tests/upstream-compat/roundtrip.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { cpSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { cleanupFixture, createIntegrationFixture } from "../integration/helpers/fixture.mjs";
+import { runSync } from "../integration/helpers/run-cli.mjs";
+
+const claudeFixtures = fileURLToPath(new URL("./claude-fixtures", import.meta.url));
+const codexFixtures = fileURLToPath(new URL("./codex-fixtures", import.meta.url));
+
+// Bad key must sit at root scope: codex --strict-config leaves the hooks table
+// array loosely validated, so an unknown key appended there is silently accepted.
+const UNKNOWN_ROOT_KEY = "totally_unknown_field_xyz = 42\n";
+const CONFIG_PARSE_ERROR = /Error loading config\.toml/;
+const CODEX_STARTED = /OpenAI Codex v/;
+const CODEX_JUDGE_TIMEOUT_MS = 12000;
+
+function binaryAvailable(name) {
+  try {
+    execFileSync(name, ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const codexMissing = binaryAvailable("codex") ? false : "codex CLI not installed";
+
+// The judge runs a non-interactive `exec` that reaches the model only AFTER the
+// config is parsed, so the config-parse verdict is emitted within ~1s. We never
+// need the model call to succeed; SIGKILL at timeout bounds the doomed network
+// attempt while the captured output already carries the verdict.
+function judgeCodexConfig(codexHome) {
+  let output;
+  try {
+    output = execFileSync("codex", ["--strict-config", "exec", "--skip-git-repo-check", "noop"], {
+      env: { PATH: process.env.PATH, HOME: process.env.HOME, CODEX_HOME: codexHome },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: CODEX_JUDGE_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+  } catch (error) {
+    output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  }
+  return {
+    output,
+    hasConfigError: CONFIG_PARSE_ERROR.test(output),
+    started: CODEX_STARTED.test(output),
+  };
+}
+
+function copyInto(src, dest) {
+  cpSync(src, dest, { recursive: true, dereference: false, verbatimSymlinks: true });
+}
+
+function syncApply(home, projectRoot, from, to) {
+  const result = runSync({
+    home,
+    projectRoot,
+    args: ["--scope", "global", "--from", from, "--to", to, "--apply"],
+  });
+  assert.equal(result.status, 0, `sync ${from}->${to} failed: ${result.output}`);
+  return result;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+// Claude skill files round-trip content-identically but the CLI normalizes the
+// filename (SKILL.md -> skill.md), so compare by body, not path.
+function readSkillBody(home, skillName) {
+  const skillDir = join(home, ".claude", "skills", skillName);
+  const markdown = readdirSync(skillDir).find((name) => /skill\.md$/i.test(name));
+  assert.ok(markdown, `no SKILL markdown found under ${skillDir}`);
+  return readFileSync(join(skillDir, markdown), "utf8");
+}
+
+test("claude->codex->claude round-trips settings, mcp, agents, and skills without loss", () => {
+  const forward = createIntegrationFixture({ scenario: "upstream-compat-forward" });
+  const reverse = createIntegrationFixture({ scenario: "upstream-compat-reverse" });
+  try {
+    copyInto(claudeFixtures, forward.home);
+    syncApply(forward.home, forward.project, "claude", "codex");
+
+    assert.ok(
+      existsSync(join(forward.home, ".codex", "config.toml")),
+      "claude->codex apply did not produce .codex/config.toml"
+    );
+
+    copyInto(join(forward.home, ".codex"), join(reverse.home, ".codex"));
+    copyInto(join(forward.home, ".agents"), join(reverse.home, ".agents"));
+    // Neutral cwd (forward.project): running the CLI from a git repo registers a
+    // [projects.<cwd>] trust block that leaks into the hooks fence and corrupts
+    // the round-trip.
+    syncApply(reverse.home, forward.project, "codex", "claude");
+
+    assert.deepEqual(
+      readJson(join(reverse.home, ".claude", "settings.json")),
+      readJson(join(claudeFixtures, ".claude", "settings.json")),
+      "permissions/hooks did not survive the round-trip"
+    );
+    assert.deepEqual(
+      readJson(join(reverse.home, ".claude.json")).mcpServers,
+      readJson(join(claudeFixtures, ".claude.json")).mcpServers,
+      "mcp servers did not survive the round-trip"
+    );
+    assert.equal(
+      readFileSync(join(reverse.home, ".claude", "agents", "sample.md"), "utf8"),
+      readFileSync(join(claudeFixtures, ".claude", "agents", "sample.md"), "utf8"),
+      "agent frontmatter did not survive the round-trip"
+    );
+    assert.equal(
+      readSkillBody(reverse.home, "sample"),
+      readFileSync(join(claudeFixtures, ".claude", "skills", "sample", "SKILL.md"), "utf8"),
+      "skill body did not survive the round-trip"
+    );
+  } finally {
+    cleanupFixture(forward);
+    cleanupFixture(reverse);
+  }
+});
+
+test("codex CLI accepts the claude->codex sync output", { skip: codexMissing }, () => {
+  const fixture = createIntegrationFixture({ scenario: "upstream-compat-host-accepts" });
+  try {
+    copyInto(claudeFixtures, fixture.home);
+    syncApply(fixture.home, fixture.project, "claude", "codex");
+
+    const verdict = judgeCodexConfig(join(fixture.home, ".codex"));
+    assert.equal(
+      verdict.hasConfigError,
+      false,
+      `codex rejected the synced config:\n${verdict.output}`
+    );
+    assert.equal(
+      verdict.started,
+      true,
+      `codex did not start up on the synced config:\n${verdict.output}`
+    );
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test("codex --strict-config rejects an unknown configuration field", { skip: codexMissing }, () => {
+  const fixture = createIntegrationFixture({ scenario: "upstream-compat-host-rejects" });
+  try {
+    copyInto(codexFixtures, fixture.home);
+    const configPath = join(fixture.home, ".codex", "config.toml");
+
+    const cleanVerdict = judgeCodexConfig(join(fixture.home, ".codex"));
+    assert.equal(
+      cleanVerdict.hasConfigError,
+      false,
+      `codex rejected the baseline codex fixture:\n${cleanVerdict.output}`
+    );
+
+    writeFileSync(configPath, UNKNOWN_ROOT_KEY + readFileSync(configPath, "utf8"));
+    const driftVerdict = judgeCodexConfig(join(fixture.home, ".codex"));
+    assert.equal(
+      driftVerdict.hasConfigError,
+      true,
+      `codex --strict-config failed to reject an unknown field:\n${driftVerdict.output}`
+    );
+  } finally {
+    cleanupFixture(fixture);
+  }
+});

--- a/tests/upstream-compat/roundtrip.test.mjs
+++ b/tests/upstream-compat/roundtrip.test.mjs
@@ -20,7 +20,9 @@ const CODEX_JUDGE_TIMEOUT_MS = 12000;
 
 function binaryAvailable(name) {
   try {
-    execFileSync(name, ["--version"], { stdio: "ignore" });
+    // Bound the probe: a hung --version (update/telemetry check) would otherwise
+    // stall module load until the CI job timeout with no diagnostic.
+    execFileSync(name, ["--version"], { stdio: "ignore", timeout: 10000, killSignal: "SIGKILL" });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
Hardening bundle for the upstream-compat pipeline. The commit history includes an add-then-revert of an LLM review step (Anthropic Consumer Terms §3-7 — subscription OAuth tokens are not permitted for unattended automation, and there are reported account suspensions: anthropics/claude-code#36324. The Layer 2/4 review moves to a local, human-triggered flow instead).

## Net changes (vs main)

**1. Extend nested allowlist scan** (`d07b82a`)
- `hash_drift_section` / `recheck_due_section` iterated `*_top_level` only → now also walk `*_nested`. Fixes the defect where the 14 nested entries first introduced in #24 were permanently excluded from schema-drift and recheck-expiry surfacing, contradicting the $schemaNote contract ("neither is a permanent exclusion").

**2. Layer 3 fixture roundtrip** (`d2f17b2`, `670de0f`) — implements the plan's Phase 2
- `tests/upstream-compat/`: uses the real codex binary as the judge — the sync output must still load under `codex --strict-config`, and claude→codex→claude must stay lossless. A permanent negative case (an unknown key is rejected) self-verifies that the judge still bites every run. Host-judge tests skip when the codex binary is absent; the pure-CLI roundtrip always runs.
- An independent `roundtrip` job in the weekly cron — no `needs` on snapshot (behavior can drift with zero schema diff, which is the whole point), files a `compatibility` issue on failure (exact-title dedupe), and does not file an issue on infra failures.

Verification: roundtrip 3 pass locally (codex 0.141.0), skip simulation, actionlint / yaml / bash -n, dedupe branch simulation. Known limitation: if codex changes its startup banner / error wording, the judge fails in the false-positive (noise) direction, not silent-miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added round-trip compatibility checks for upstream configuration syncing between supported CLIs.
  * Expanded compatibility review coverage to include nested schema entries.

* **Bug Fixes**
  * Improved re-review scheduling so overdue nested items are picked up correctly.
  * Added automated issue/comment reporting when round-trip compatibility fails.

* **Tests**
  * Added broader integration coverage for synced settings, MCP servers, agents, skills, and strict config validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->