### PR TITLE
fix(rules): register OrchestratorToml.mcp/skills and tighten hash test to top_level

### DIFF
--- a/rules/upstream-known-unsupported.json
+++ b/rules/upstream-known-unsupported.json
@@ -130,6 +130,26 @@
       },
       "recheck_after": "2027-01-02"
     },
+    "OrchestratorToml.mcp": {
+      "reason": "Codex orchestrator-subsystem feature toggle (bare $ref to OrchestratorFeatureToml {enabled}); unrelated to Claude mcpServers/skills content configs. See codex_top_level.orchestrator.",
+      "decided_in": "#24",
+      "decided_at": "2026-07-02",
+      "direction": {
+        "claude_to_codex": "drop",
+        "codex_to_claude": "drop"
+      },
+      "recheck_after": "2027-01-02"
+    },
+    "OrchestratorToml.skills": {
+      "reason": "Codex orchestrator-subsystem feature toggle (bare $ref to OrchestratorFeatureToml {enabled}); unrelated to Claude mcpServers/skills content configs. See codex_top_level.orchestrator.",
+      "decided_in": "#24",
+      "decided_at": "2026-07-02",
+      "direction": {
+        "claude_to_codex": "drop",
+        "codex_to_claude": "drop"
+      },
+      "recheck_after": "2027-01-02"
+    },
     "RolloutBudgetConfigToml.enabled": {
       "reason": "Codex rollout weighted-token budget; no Claude equivalent.",
       "decided_in": "#24",

--- a/tests/upstream-known-unsupported.test.mjs
+++ b/tests/upstream-known-unsupported.test.mjs
@@ -50,8 +50,8 @@ test("upstream-known-unsupported.json entries declare required fields with corre
       assert.equal(typeof entry.decided_in, "string", `${where}.decided_in must be a string`);
       assert.match(entry.decided_at, ISO_DATE, `${where}.decided_at must be YYYY-MM-DD`);
       assert.match(entry.recheck_after, ISO_DATE, `${where}.recheck_after must be YYYY-MM-DD`);
-      // schema_desc_hash is omitted for fields whose schema carries no description (the scan skips empty-desc entries).
-      if ("schema_desc_hash" in entry) {
+      // top_level entries must carry a hash (hash_drift_section consumes only top_level; a missing hash emits phantom drift every run). nested fields whose schema is a bare $ref / has no description omit it, matching the scan's empty-desc skip.
+      if (scope.endsWith("_top_level") || "schema_desc_hash" in entry) {
         assert.match(
           entry.schema_desc_hash,
           SHORT_SHA256,


### PR DESCRIPTION
Follow-up to #24. An edge review found the 2026-06-26 drift actually added **17** new keys, not 15 — `OrchestratorToml.mcp` and `.skills` were silently treated as covered because the compat scan's nested coverage check greps only the leaf name, which collides with the same-named rules category keys (`"mcp":`, `"skills":`), yielding a false-covered verdict that kept them out of the scan.

- Both keys are bare $ref pointers to `OrchestratorFeatureToml {enabled}` — Codex orchestrator-internal toggles. They have no relation to Claude's mcpServers/skills (content configs), so they are registered as `drop`.
- The hash-test relaxation is narrowed: top_level entries still require a hash (hash_drift_section consumes only top_level, so a missing hash emits phantom drift every run), while nested fields whose schema is a bare $ref / has no description may omit it.

Verification: `node --test tests/upstream-known-unsupported.test.mjs` → 5 pass, plus a negative check confirming a top_level entry without a hash fails.