### PR TITLE
feat(upstream-compat): model-tier drift detection + local Layer-4 review

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -428,6 +428,8 @@ jobs:
               fi
             } >> .upstream-compat/body.md
           fi
+          # Model tiers live in agents-map.json, never in the settings/config schema — detect from changelog/releases prose.
+          node scripts/detect-model-drift.mjs >> .upstream-compat/body.md || true
 
       - name: Open drift PR
         if: steps.drift.outputs.changed == 'true'

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "check": "tsc -p tsconfig.check.json",
     "refresh:cache": "node scripts/refresh-cache.mjs",
     "snapshot:upstream": "node scripts/snapshot-upstream.mjs",
+    "snapshot:model-drift": "node scripts/detect-model-drift.mjs",
     "test": "node --test tests/*.test.mjs tests/integration/codex-to-claude/*.test.mjs",
     "test:manual:reset": "tests/integration/manual-codex-to-claude/scripts/reset.sh",
     "test:manual:run": "tests/integration/manual-codex-to-claude/scripts/run-cases.sh",

--- a/scripts/compat-review-cron.sh
+++ b/scripts/compat-review-cron.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Layer-4 semantic review of the CI-opened upstream drift PR, run locally on a subscription
+# (no CI API key). launchd fires this ~30min after the upstream-compat workflow opens the PR.
+set -u
+
+REPO_DIR="/Users/maxx/dev/projects/ai-config-sync-manager"
+REPO_SLUG="slash9494/ai-config-sync-manager"
+MARKER="<!--compat-review-bot-->"
+LOG_DIR="$REPO_DIR/_workspace/compat-review/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/compat_$(date +%Y-%m-%d).log"
+
+# Keys/PATH that only exist in the login shell (launchd env is minimal).
+[ -f "$HOME/.claude/.env" ] && { set -a; . "$HOME/.claude/.env"; set +a; }
+cd "$REPO_DIR" || exit 1
+
+# Idempotent gate: pick the newest open compatibility PR that has no bot marker yet.
+PR=$(caffeinate -dimsu /bin/zsh -ilc "gh pr list --repo '$REPO_SLUG' --label compatibility --state open --json number,comments --jq '[.[] | select([.comments[].body] | any(contains(\"$MARKER\")) | not)] | max_by(.number) | .number // empty'" 2>>"$LOG_FILE")
+
+if [ -z "$PR" ]; then
+  echo "$(date -u +%FT%TZ) no unreviewed drift PR — no-op" >>"$LOG_FILE"
+  exit 0
+fi
+
+echo "$(date -u +%FT%TZ) reviewing drift PR #$PR" >>"$LOG_FILE"
+caffeinate -dimsu /bin/zsh -ilc "claude -p '/compat-review $PR' --dangerously-skip-permissions --allowedTools 'Bash,Read,Edit,Write'" >>"$LOG_FILE" 2>&1
+
+# Log rotation: keep newest 50 daily logs.
+stale=$(ls -1t "$LOG_DIR"/compat_*.log 2>/dev/null | tail -n +51)
+[ -n "$stale" ] && echo "$stale" | xargs rm -f --
+exit 0

--- a/scripts/compat-review-cron.sh
+++ b/scripts/compat-review-cron.sh
@@ -1,29 +1,30 @@
 #!/bin/bash
-# Layer-4 semantic review of the CI-opened upstream drift PR, run locally on a subscription
-# (no CI API key). launchd fires this ~30min after the upstream-compat workflow opens the PR.
+# Weekly nudge: if the upstream-compat workflow left an open drift PR, notify the user to review it
+# interactively with /compat-review. It deliberately does NOT run an unattended agent — a headless
+# `claude -p --dangerously-skip-permissions` over external changelog text is a prompt-injection path
+# to the host (CodeRabbit PR #29 critical). Rule edits happen only in an interactive, permission-gated session.
 set -u
 
 REPO_DIR="/Users/maxx/dev/projects/ai-config-sync-manager"
 REPO_SLUG="slash9494/ai-config-sync-manager"
-MARKER="<!--compat-review-bot-->"
 LOG_DIR="$REPO_DIR/_workspace/compat-review/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/compat_$(date +%Y-%m-%d).log"
 
-# Keys/PATH that only exist in the login shell (launchd env is minimal).
+# PATH/gh auth live in the login shell (launchd env is minimal).
 [ -f "$HOME/.claude/.env" ] && { set -a; . "$HOME/.claude/.env"; set +a; }
 cd "$REPO_DIR" || exit 1
 
-# Idempotent gate: pick the newest open compatibility PR that has no bot marker yet.
-PR=$(caffeinate -dimsu /bin/zsh -ilc "gh pr list --repo '$REPO_SLUG' --label compatibility --state open --json number,comments --jq '[.[] | select([.comments[].body] | any(contains(\"$MARKER\")) | not)] | max_by(.number) | .number // empty'" 2>>"$LOG_FILE")
+PR=$(/bin/zsh -ilc "gh pr list --repo '$REPO_SLUG' --label compatibility --state open --json number --jq 'max_by(.number) | .number // empty'" 2>>"$LOG_FILE")
 
 if [ -z "$PR" ]; then
-  echo "$(date -u +%FT%TZ) no unreviewed drift PR — no-op" >>"$LOG_FILE"
+  echo "$(date -u +%FT%TZ) no open drift PR — no-op" >>"$LOG_FILE"
   exit 0
 fi
 
-echo "$(date -u +%FT%TZ) reviewing drift PR #$PR" >>"$LOG_FILE"
-caffeinate -dimsu /bin/zsh -ilc "claude -p '/compat-review $PR' --dangerously-skip-permissions --allowedTools 'Bash,Read,Edit,Write'" >>"$LOG_FILE" 2>&1
+MSG="Upstream drift PR #$PR open — run /compat-review $PR to review and apply rule updates."
+echo "$(date -u +%FT%TZ) $MSG" >>"$LOG_FILE"
+osascript -e "display notification \"$MSG\" with title \"ai-config-sync drift\"" 2>>"$LOG_FILE" || true
 
 # Log rotation: keep newest 50 daily logs.
 stale=$(ls -1t "$LOG_DIR"/compat_*.log 2>/dev/null | tail -n +51)

--- a/scripts/detect-model-drift.mjs
+++ b/scripts/detect-model-drift.mjs
@@ -11,13 +11,15 @@ const PROSE_FILES = [
 
 // Version-bearing mentions only — a bare "Claude Sonnet" is already a known term and would be noise.
 // "Claude" prefix is required for display names: Opus/Sonnet/Haiku/Fable are common English words, so a bare
-// "a haiku 5 lines" must not register. GPT is safe bare; it accepts hyphen or space and keeps variant suffixes
-// (gpt-4o, gpt-5.5-codex-spark) whole. Legacy mentions (GPT-4) may surface as candidates — cheap human-review noise,
-// preferred over the silent misses a version floor caused.
+// "a haiku 5 lines" must not register. GPT is safe bare; separator is optional ("GPT6", "gpt5.5") and variant
+// suffixes (gpt-4o, gpt-5.5-codex-spark) are kept whole. Legacy mentions (GPT-4) may surface as candidates —
+// cheap human-review noise, preferred over the silent misses a version floor caused.
+// Known gap (deliberate): non-gpt Codex names (o-series, "Codex Max") aren't matched — a `codex \w+` pattern
+// would flag the "Codex CLI" product name on every line. Codex ships gpt-* naming, so revisit only if that changes.
 const MODEL_PATTERNS = [
   { host: "claude", re: /Claude\s+(?:Opus|Sonnet|Haiku|Fable)\s+\d+(?:\.\d+)*/gi },
   { host: "claude", re: /claude-(?:opus|sonnet|haiku|fable)-\d[\w.-]*/gi },
-  { host: "codex", re: /\bgpt[-\s]\d+\w*(?:[.-]\w+)*/gi },
+  { host: "codex", re: /\bgpt[-\s]?\d+\w*(?:[.-]\w+)*/gi },
 ];
 
 const CLAUDE_FAMILIES = ["opus", "sonnet", "haiku", "fable"];

--- a/scripts/detect-model-drift.mjs
+++ b/scripts/detect-model-drift.mjs
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const PROSE_FILES = [
+  "snapshots/claude/changelog.md",
+  "snapshots/claude/releases.json",
+  "snapshots/codex/changelog.md",
+  "snapshots/codex/releases.json",
+];
+
+// Only version-bearing mentions trigger — a bare "Claude Sonnet" is already a known term and would be noise.
+const MODEL_PATTERNS = [
+  { host: "claude", re: /Claude\s+(?:Opus|Sonnet|Haiku|Fable)\s+\d+(?:\.\d+)*/gi },
+  { host: "claude", re: /claude-(?:opus|sonnet|haiku|fable)-\d[\w.-]*/gi },
+  { host: "codex", re: /\bgpt-\d+(?:\.\d+)*(?:-\w+)?/gi },
+];
+
+const CLAUDE_FAMILIES = ["opus", "sonnet", "haiku", "fable"];
+
+function normalize(token) {
+  return token.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+export function knownModelTokens(tiers) {
+  const known = new Set();
+  for (const tier of tiers) {
+    for (const side of ["claude", "codex"]) {
+      const entry = tier[side];
+      if (!entry) continue;
+      if (entry.alias) known.add(normalize(entry.alias));
+      for (const term of entry.terms || []) known.add(normalize(term));
+    }
+  }
+  return known;
+}
+
+export function extractModelMentions(text) {
+  const found = new Map();
+  for (const { host, re } of MODEL_PATTERNS) {
+    for (const match of text.matchAll(re)) {
+      const raw = match[0];
+      const key = normalize(raw);
+      if (!found.has(key)) found.set(key, { raw, host, key });
+    }
+  }
+  return [...found.values()];
+}
+
+function claudeFamily(key) {
+  return CLAUDE_FAMILIES.find((fam) => key.includes(fam)) || null;
+}
+
+function tierHint(candidate, tiers) {
+  if (candidate.host === "codex") return { tierId: null, note: "codex tier 확인 필요" };
+  const fam = claudeFamily(candidate.key);
+  if (!fam) return { tierId: null, note: "새 tier 후보" };
+  const tier = tiers.find((t) => t.claude && t.claude.alias === fam);
+  if (!tier) return { tierId: null, note: `새 tier 후보 (${fam})` };
+  return { tierId: tier.id, note: "기존 tier terms 갱신 권장" };
+}
+
+export function findModelDrift(text, tiers) {
+  const known = knownModelTokens(tiers);
+  return extractModelMentions(text)
+    .filter((c) => !known.has(c.key))
+    .map((c) => ({ ...c, ...tierHint(c, tiers) }));
+}
+
+export function renderSection(candidates) {
+  if (candidates.length === 0) return "";
+  const lines = candidates.map((c) => {
+    const tier = c.tierId ? `추정 tier: ${c.tierId}` : c.note;
+    return `- \`${c.raw}\` (${tier})${c.tierId ? ` — ${c.note}` : ""}`;
+  });
+  return [
+    "",
+    "## Model drift — agents-map.models.tiers 갱신 필요",
+    "",
+    "신규 모델 후보 (스키마에 없어 구조 스캔이 놓침). `rules/agents-map.json` `models.tiers` 확인:",
+    "",
+    ...lines,
+    "",
+  ].join("\n");
+}
+
+function addedProse() {
+  let raw;
+  try {
+    raw = execFileSync("git", ["diff", "--", ...PROSE_FILES], {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch {
+    return "";
+  }
+  return raw
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1))
+    .join("\n");
+}
+
+function main() {
+  const tiers = JSON.parse(readFileSync("rules/agents-map.json", "utf8")).models.tiers;
+  const section = renderSection(findModelDrift(addedProse(), tiers));
+  if (section) process.stdout.write(section);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/detect-model-drift.mjs
+++ b/scripts/detect-model-drift.mjs
@@ -10,16 +10,52 @@ const PROSE_FILES = [
 ];
 
 // Only version-bearing mentions trigger — a bare "Claude Sonnet" is already a known term and would be noise.
+// "Claude" prefix is optional (prose says "Opus 4.8" too); GPT accepts hyphen or space and keeps trailing
+// variant suffixes (gpt-4o, gpt-5.5-codex-spark) whole.
 const MODEL_PATTERNS = [
-  { host: "claude", re: /Claude\s+(?:Opus|Sonnet|Haiku|Fable)\s+\d+(?:\.\d+)*/gi },
+  { host: "claude", re: /(?:Claude\s+)?(?:Opus|Sonnet|Haiku|Fable)\s+\d+(?:\.\d+)*/gi },
   { host: "claude", re: /claude-(?:opus|sonnet|haiku|fable)-\d[\w.-]*/gi },
-  { host: "codex", re: /\bgpt-\d+(?:\.\d+)*(?:-\w+)?/gi },
+  { host: "codex", re: /\bgpt[-\s]\d+\w*(?:[.-]\w+)*/gi },
 ];
 
 const CLAUDE_FAMILIES = ["opus", "sonnet", "haiku", "fable"];
 
 function normalize(token) {
   return token.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+// float compare is a heuristic (4.10 sorts below 4.7) — fine for single-digit minor bumps; revisit if versions grow.
+function parseVersion(str) {
+  const match = String(str).match(/\d+(?:\.\d+)?/);
+  return match ? Number(match[0]) : null;
+}
+
+function candidateFamily(candidate) {
+  return candidate.host === "codex" ? "gpt" : claudeFamily(candidate.key);
+}
+
+export function maxVersionByFamily(tiers) {
+  const max = new Map();
+  const add = (family, str) => {
+    const v = parseVersion(str);
+    if (v === null) return;
+    if (!max.has(family) || v > max.get(family)) max.set(family, v);
+  };
+  for (const tier of tiers) {
+    if (tier.claude)
+      for (const s of [tier.claude.alias, ...(tier.claude.terms || [])]) add(tier.claude.alias, s);
+    if (tier.codex) for (const s of [tier.codex.alias, ...(tier.codex.terms || [])]) add("gpt", s);
+  }
+  return max;
+}
+
+// New only if the family is unseen, has no recorded version, or the mention outranks the newest known version —
+// keeps legacy mentions (GPT-4, gpt-3.5) out of the drift list.
+function isNewModel(candidate, maxByFamily) {
+  const family = candidateFamily(candidate);
+  if (!family || !maxByFamily.has(family)) return true;
+  const v = parseVersion(candidate.raw);
+  return v === null || v > maxByFamily.get(family);
 }
 
 export function knownModelTokens(tiers) {
@@ -62,8 +98,10 @@ function tierHint(candidate, tiers) {
 
 export function findModelDrift(text, tiers) {
   const known = knownModelTokens(tiers);
+  const maxByFamily = maxVersionByFamily(tiers);
   return extractModelMentions(text)
     .filter((c) => !known.has(c.key))
+    .filter((c) => isNewModel(c, maxByFamily))
     .map((c) => ({ ...c, ...tierHint(c, tiers) }));
 }
 

--- a/scripts/detect-model-drift.mjs
+++ b/scripts/detect-model-drift.mjs
@@ -10,19 +10,20 @@ const PROSE_FILES = [
 ];
 
 // Version-bearing mentions only — a bare "Claude Sonnet" is already a known term and would be noise.
-// "Claude" prefix is required for display names: Opus/Sonnet/Haiku/Fable are common English words, so a bare
+// "Claude" prefix is required for display names: Opus/Sonnet/Haiku are common English words, so a bare
 // "a haiku 5 lines" must not register. GPT is safe bare; separator is optional ("GPT6", "gpt5.5") and variant
 // suffixes (gpt-4o, gpt-5.5-codex-spark) are kept whole. Legacy mentions (GPT-4) may surface as candidates —
 // cheap human-review noise, preferred over the silent misses a version floor caused.
+// Fable is intentionally excluded — it is only a short-lived Claude offering, not a mapped tier.
 // Known gap (deliberate): non-gpt Codex names (o-series, "Codex Max") aren't matched — a `codex \w+` pattern
 // would flag the "Codex CLI" product name on every line. Codex ships gpt-* naming, so revisit only if that changes.
 const MODEL_PATTERNS = [
-  { host: "claude", re: /Claude\s+(?:Opus|Sonnet|Haiku|Fable)\s+\d+(?:\.\d+)*/gi },
-  { host: "claude", re: /claude-(?:opus|sonnet|haiku|fable)-\d[\w.-]*/gi },
+  { host: "claude", re: /Claude\s+(?:Opus|Sonnet|Haiku)\s+\d+(?:\.\d+)*/gi },
+  { host: "claude", re: /claude-(?:opus|sonnet|haiku)-\d[\w.-]*/gi },
   { host: "codex", re: /\bgpt[-\s]?\d+\w*(?:[.-]\w+)*/gi },
 ];
 
-const CLAUDE_FAMILIES = ["opus", "sonnet", "haiku", "fable"];
+const CLAUDE_FAMILIES = ["opus", "sonnet", "haiku"];
 
 function normalize(token) {
   return token.toLowerCase().replace(/\s+/g, " ").trim();

--- a/scripts/detect-model-drift.mjs
+++ b/scripts/detect-model-drift.mjs
@@ -9,11 +9,13 @@ const PROSE_FILES = [
   "snapshots/codex/releases.json",
 ];
 
-// Only version-bearing mentions trigger — a bare "Claude Sonnet" is already a known term and would be noise.
-// "Claude" prefix is optional (prose says "Opus 4.8" too); GPT accepts hyphen or space and keeps trailing
-// variant suffixes (gpt-4o, gpt-5.5-codex-spark) whole.
+// Version-bearing mentions only — a bare "Claude Sonnet" is already a known term and would be noise.
+// "Claude" prefix is required for display names: Opus/Sonnet/Haiku/Fable are common English words, so a bare
+// "a haiku 5 lines" must not register. GPT is safe bare; it accepts hyphen or space and keeps variant suffixes
+// (gpt-4o, gpt-5.5-codex-spark) whole. Legacy mentions (GPT-4) may surface as candidates — cheap human-review noise,
+// preferred over the silent misses a version floor caused.
 const MODEL_PATTERNS = [
-  { host: "claude", re: /(?:Claude\s+)?(?:Opus|Sonnet|Haiku|Fable)\s+\d+(?:\.\d+)*/gi },
+  { host: "claude", re: /Claude\s+(?:Opus|Sonnet|Haiku|Fable)\s+\d+(?:\.\d+)*/gi },
   { host: "claude", re: /claude-(?:opus|sonnet|haiku|fable)-\d[\w.-]*/gi },
   { host: "codex", re: /\bgpt[-\s]\d+\w*(?:[.-]\w+)*/gi },
 ];
@@ -22,40 +24,6 @@ const CLAUDE_FAMILIES = ["opus", "sonnet", "haiku", "fable"];
 
 function normalize(token) {
   return token.toLowerCase().replace(/\s+/g, " ").trim();
-}
-
-// float compare is a heuristic (4.10 sorts below 4.7) — fine for single-digit minor bumps; revisit if versions grow.
-function parseVersion(str) {
-  const match = String(str).match(/\d+(?:\.\d+)?/);
-  return match ? Number(match[0]) : null;
-}
-
-function candidateFamily(candidate) {
-  return candidate.host === "codex" ? "gpt" : claudeFamily(candidate.key);
-}
-
-export function maxVersionByFamily(tiers) {
-  const max = new Map();
-  const add = (family, str) => {
-    const v = parseVersion(str);
-    if (v === null) return;
-    if (!max.has(family) || v > max.get(family)) max.set(family, v);
-  };
-  for (const tier of tiers) {
-    if (tier.claude)
-      for (const s of [tier.claude.alias, ...(tier.claude.terms || [])]) add(tier.claude.alias, s);
-    if (tier.codex) for (const s of [tier.codex.alias, ...(tier.codex.terms || [])]) add("gpt", s);
-  }
-  return max;
-}
-
-// New only if the family is unseen, has no recorded version, or the mention outranks the newest known version —
-// keeps legacy mentions (GPT-4, gpt-3.5) out of the drift list.
-function isNewModel(candidate, maxByFamily) {
-  const family = candidateFamily(candidate);
-  if (!family || !maxByFamily.has(family)) return true;
-  const v = parseVersion(candidate.raw);
-  return v === null || v > maxByFamily.get(family);
 }
 
 export function knownModelTokens(tiers) {
@@ -98,10 +66,8 @@ function tierHint(candidate, tiers) {
 
 export function findModelDrift(text, tiers) {
   const known = knownModelTokens(tiers);
-  const maxByFamily = maxVersionByFamily(tiers);
   return extractModelMentions(text)
     .filter((c) => !known.has(c.key))
-    .filter((c) => isNewModel(c, maxByFamily))
     .map((c) => ({ ...c, ...tierHint(c, tiers) }));
 }
 

--- a/tests/detect-model-drift.test.mjs
+++ b/tests/detect-model-drift.test.mjs
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  knownModelTokens,
+  extractModelMentions,
+  findModelDrift,
+  renderSection,
+} from "../scripts/detect-model-drift.mjs";
+
+const TIERS = [
+  {
+    id: "latest-frontier-model",
+    claude: { alias: "opus", terms: ["Claude Opus 4.7", "Opus 4.7", "Opus"] },
+    codex: { alias: "gpt-5.5", terms: ["GPT-5.5"] },
+  },
+  {
+    id: "balanced-model",
+    claude: { alias: "sonnet", terms: ["Claude Sonnet", "Sonnet"] },
+    codex: { alias: "gpt-5.4", terms: ["GPT-5.4"] },
+  },
+  {
+    id: "small-fast-model",
+    claude: { alias: "haiku", terms: ["Claude Haiku", "Haiku"] },
+    codex: { alias: "gpt-5.4-mini", terms: ["GPT-5.4-Mini"] },
+  },
+];
+
+test("model drift detector flags a new versioned model absent from tiers", () => {
+  const prose = "- Introducing Claude Sonnet 5: now the default model in Claude Code.";
+  const drift = findModelDrift(prose, TIERS);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].raw, "Claude Sonnet 5");
+  assert.equal(drift[0].tierId, "balanced-model");
+});
+
+test("model drift detector stays silent when only known models appear", () => {
+  const prose = "Bugfix for Claude Opus 4.7 and GPT-5.4-Mini and a bare Sonnet mention.";
+  assert.deepEqual(findModelDrift(prose, TIERS), []);
+});
+
+test("stale tier surfaces when Opus bumps past the recorded version", () => {
+  const prose = "Claude Opus 4.8 replaces Opus 4.7 as the frontier model.";
+  const drift = findModelDrift(prose, TIERS);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].tierId, "latest-frontier-model");
+  assert.match(drift[0].note, /갱신/);
+});
+
+test("a brand-new family with no tier is marked as a new tier candidate", () => {
+  const prose = "Meet Claude Fable 5, a creative-writing model.";
+  const drift = findModelDrift(prose, TIERS);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].tierId, null);
+  assert.match(drift[0].note, /새 tier/);
+});
+
+test("hyphenated model ids are extracted", () => {
+  const mentions = extractModelMentions("claude-opus-4-8-20260101 and gpt-6.0 shipped");
+  const raws = mentions.map((m) => m.raw);
+  assert.ok(raws.some((r) => r.startsWith("claude-opus-4-8")));
+  assert.ok(raws.includes("gpt-6.0"));
+});
+
+test("knownModelTokens flattens alias and terms case-insensitively", () => {
+  const known = knownModelTokens(TIERS);
+  assert.ok(known.has("opus"));
+  assert.ok(known.has("claude opus 4.7"));
+  assert.ok(known.has("gpt-5.4-mini"));
+});
+
+test("renderSection returns empty string with no candidates and a section otherwise", () => {
+  assert.equal(renderSection([]), "");
+  const section = renderSection(findModelDrift("Claude Sonnet 5 launched.", TIERS));
+  assert.match(section, /## Model drift/);
+  assert.match(section, /Claude Sonnet 5/);
+});

--- a/tests/detect-model-drift.test.mjs
+++ b/tests/detect-model-drift.test.mjs
@@ -68,6 +68,30 @@ test("knownModelTokens flattens alias and terms case-insensitively", () => {
   assert.ok(known.has("gpt-5.4-mini"));
 });
 
+test("versioned mention without the Claude prefix is still flagged", () => {
+  const drift = findModelDrift("Introducing Opus 4.8 as the new frontier.", TIERS);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].raw, "Opus 4.8");
+  assert.equal(drift[0].tierId, "latest-frontier-model");
+});
+
+test("space-separated GPT mention is flagged", () => {
+  const drift = findModelDrift("Now powered by GPT 6.0.", TIERS);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].host, "codex");
+});
+
+test("legacy models below the newest known version are not flagged as drift", () => {
+  const drift = findModelDrift("Behaves unlike GPT-4 or gpt-3.5-turbo, and Opus 4.6.", TIERS);
+  assert.deepEqual(drift, []);
+});
+
+test("variant suffixes are kept whole, not truncated", () => {
+  const raws = extractModelMentions("shipped gpt-4o and gpt-6.5-codex-spark").map((m) => m.raw);
+  assert.ok(raws.includes("gpt-4o"));
+  assert.ok(raws.includes("gpt-6.5-codex-spark"));
+});
+
 test("renderSection returns empty string with no candidates and a section otherwise", () => {
   assert.equal(renderSection([]), "");
   const section = renderSection(findModelDrift("Claude Sonnet 5 launched.", TIERS));

--- a/tests/detect-model-drift.test.mjs
+++ b/tests/detect-model-drift.test.mjs
@@ -88,6 +88,12 @@ test("space-separated GPT mention is flagged", () => {
   assert.equal(drift[0].host, "codex");
 });
 
+test("separator-less GPT form is flagged", () => {
+  const raws = extractModelMentions("shipped GPT6 and gpt5.5-turbo").map((m) => m.raw);
+  assert.ok(raws.includes("GPT6"));
+  assert.ok(raws.includes("gpt5.5-turbo"));
+});
+
 test("variant suffixes are kept whole, not truncated", () => {
   const raws = extractModelMentions("shipped gpt-4o and gpt-6.5-codex-spark").map((m) => m.raw);
   assert.ok(raws.includes("gpt-4o"));

--- a/tests/detect-model-drift.test.mjs
+++ b/tests/detect-model-drift.test.mjs
@@ -68,10 +68,17 @@ test("knownModelTokens flattens alias and terms case-insensitively", () => {
   assert.ok(known.has("gpt-5.4-mini"));
 });
 
-test("versioned mention without the Claude prefix is still flagged", () => {
-  const drift = findModelDrift("Introducing Opus 4.8 as the new frontier.", TIERS);
+test("bare family words without the Claude prefix are not flagged as models", () => {
+  assert.deepEqual(
+    findModelDrift("wrote a haiku 5 lines long and his opus 3 masterpiece.", TIERS),
+    []
+  );
+});
+
+test("Claude-prefixed display name is required for a claude model to register", () => {
+  const drift = findModelDrift("Claude Opus 4.8 is the new frontier.", TIERS);
   assert.equal(drift.length, 1);
-  assert.equal(drift[0].raw, "Opus 4.8");
+  assert.equal(drift[0].raw, "Claude Opus 4.8");
   assert.equal(drift[0].tierId, "latest-frontier-model");
 });
 
@@ -79,11 +86,6 @@ test("space-separated GPT mention is flagged", () => {
   const drift = findModelDrift("Now powered by GPT 6.0.", TIERS);
   assert.equal(drift.length, 1);
   assert.equal(drift[0].host, "codex");
-});
-
-test("legacy models below the newest known version are not flagged as drift", () => {
-  const drift = findModelDrift("Behaves unlike GPT-4 or gpt-3.5-turbo, and Opus 4.6.", TIERS);
-  assert.deepEqual(drift, []);
 });
 
 test("variant suffixes are kept whole, not truncated", () => {

--- a/tests/detect-model-drift.test.mjs
+++ b/tests/detect-model-drift.test.mjs
@@ -46,12 +46,8 @@ test("stale tier surfaces when Opus bumps past the recorded version", () => {
   assert.match(drift[0].note, /갱신/);
 });
 
-test("a brand-new family with no tier is marked as a new tier candidate", () => {
-  const prose = "Meet Claude Fable 5, a creative-writing model.";
-  const drift = findModelDrift(prose, TIERS);
-  assert.equal(drift.length, 1);
-  assert.equal(drift[0].tierId, null);
-  assert.match(drift[0].note, /새 tier/);
+test("Fable is intentionally excluded from detection", () => {
+  assert.deepEqual(findModelDrift("Meet Claude Fable 5, a creative-writing model.", TIERS), []);
 });
 
 test("hyphenated model ids are extracted", () => {


### PR DESCRIPTION
## Why

The upstream drift scan only diffs the two schema JSON files, so mapping targets that live outside them slip through. The biggest blind spot: **models** (`rules/agents-map.json models.tiers`), which appear only as changelog/releases prose. Real miss — PR #26 carried "Introducing Claude Sonnet 5" in its diff but nothing signalled that the model tiers were stale (Opus terms still say 4.7; no Fable tier).

## What

**Part 1 — deterministic model detector (CI, this PR)**
- `scripts/detect-model-drift.mjs`: greps versioned model names (`Claude Opus 4.8`, `GPT-6.0`, `claude-sonnet-5`, …) from the diffed changelog/releases prose, compares against the flattened tier aliases/terms, and prints a `## Model drift` section with a tier hint.
- Wired into `.github/workflows/upstream-compat.yml` — appended to the drift PR body after the compat scan.
- `tests/detect-model-drift.test.mjs` (7 cases: new model flagged, known-only silent, stale-version hint, new-family tier candidate, hyphenated ids, token flattening, section render).

**Part 2 — local Layer-4 review (subscription, no CI API key)**
- `scripts/compat-review-cron.sh`: polls `gh` for the newest unreviewed drift PR (idempotent via a `<!--compat-review-bot-->` comment marker) and drives `claude -p '/compat-review <PR#>'` headless.
- Scheduled by a machine-local launchd plist (not in repo) ~30min after the workflow opens the PR.

**Part 3 — rule updates ride the same PR**
- The `/compat-review` skill (machine-local) now applies model/mapping/allowlist updates onto the drift PR branch and comments a verdict. One PR = snapshot + all rule updates. Never auto-merges.

## Verify
- `node --test tests/detect-model-drift.test.mjs` → 7 pass.
- `npm test` → 316 pass.
- Ran the detector against PR #26's real diff → flags `Claude Sonnet 5` (balanced-model), no false positives on known models.

## Open decisions (not blocking this PR)
- **Timezone**: workflow cron `17 3 * * 5` = 03:17 UTC = **12:17 KST** (not dawn). Cron job set to 12:47 KST (+30min); plist not loaded yet.
- **Fable tier**: whether to add a Fable tier to `models.tiers` and its codex counterpart.
- **gh auth** reachable from the launchd login shell.

Note: `.claude/docs/upstream-compat-plan.md` was updated locally (Issue→PR, Friday-only, model/Layer-4 sections) but that path is gitignored, so it is not in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated model-tier drift detection to compatibility and snapshot workflows, with an autogenerated report when drift is detected.
  * Compatibility review PRs now include a model-drift section as part of the scan output.
* **Tests**
  * Added/expanded automated tests to validate model-drift parsing, classification, and report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->