### PR TITLE
feat(board): open the board in the browser by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ ai-config-sync sync --include instructions,skills:code-writer --exclude mcp --dr
 ai-config-sync sync --from claude --to codex
 ai-config-sync sync --from codex --to claude
 ai-config-sync board
-ai-config-sync board --scope global --open
+ai-config-sync board --scope global --no-open
 ai-config-sync reference
 ai-config-sync paraphrase
 ```
@@ -153,7 +153,7 @@ ai-config-sync status --scope project --tree --include skills:code-writer
 
 ### `board`
 
-Renders a self-contained HTML inventory board — every skill, agent, hook, and MCP server on both hosts in one dense view, colored by sync status: green = in sync, red = conflict, gray = one host only, amber = unsupported. Type in the filter box to narrow rows; click a row for the full description, paths, and status detail. The file is written to `~/.ai-config-sync-manager/board/` with no external requests, so it works offline.
+Renders a self-contained HTML inventory board — every skill, agent, hook, and MCP server on both hosts, split into per-area tabs, colored by sync status: green = in sync, red = conflict, blue = Claude only, purple = Codex only, amber = unsupported. Agents are grouped under their harness (subfolder) where they have one. Type in the filter box to narrow rows; click a row for the full description, paths, and status detail. The file is written to `~/.ai-config-sync-manager/board/` with no external requests, so it works offline, and opens in your default browser automatically (pass `--no-open` to skip).
 
 <img src="https://raw.githubusercontent.com/slash9494/ai-config-sync-manager/main/assets/board_preview.png" alt="ai-config-sync board — inventory of agents, skills, mcp, and hooks colored by sync status" width="100%" />
 
@@ -162,11 +162,11 @@ Renders a self-contained HTML inventory board — every skill, agent, hook, and 
 | `--scope global\|project\|all` | Limit scope (default: `all` = global + project) |
 | `--include area[:item][,...]` | Include selector — see [Selector syntax](#selector-syntax) |
 | `--exclude area[:item][,...]` | Exclude selector — see [Selector syntax](#selector-syntax) |
-| `--open` | Open the generated board in the default browser |
+| `--no-open` | Only write the file; do not open a browser |
 | `-h`, `--help` | Show board help |
 
 ```bash
-ai-config-sync board --scope global --open
+ai-config-sync board --scope global
 ```
 
 ### `sync`

--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -11,7 +11,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { basename, dirname, join, parse, relative, resolve } from "node:path";
@@ -30,6 +30,8 @@ const BACKUP_RETENTION = 30;
 const LEDGER_RETENTION = 300;
 const STATUS_DETAILS_RETENTION = 100;
 const BOARD_RETENTION = 100;
+// Areas the board inventories; overlays outside this set (permissions/plugins) are out of board scope.
+const BOARD_AREAS = new Set(["skills", "agents", "hooks", "mcp"]);
 const CODEX_PLUGIN_NAME = "ai-config-sync-manager";
 const CODEX_MARKETPLACE_NAME = "local-plugins";
 const runtimePackage = readRuntimePackage();
@@ -230,7 +232,34 @@ function buildBoardInventory(scopes, selectors = emptySelectors()) {
     collectSettingsInventory(items, scope, "hooks", paths);
     collectMcpInventory(items, scope, paths);
   }
-  return filterBoardInventory(items, selectors);
+  return filterBoardInventory(filterIgnoredInventory(items), selectors);
+}
+
+function filterIgnoredInventory(items) {
+  const rules = (ignoreListSource().data?.exclude ?? []).filter(Boolean);
+  if (rules.length === 0) return items;
+  return items.filter(
+    (item) => !ignoreRulesMatchEntry(rules, inventoryIgnoreEntry(item), item.name)
+  );
+}
+
+function inventoryIgnoreEntry(item) {
+  // Skills carry the item dir in claudePath/codexPath, but status compares against the base dir
+  // (name excluded); strip the name so path-form ignore rules resolve identically on both sides.
+  if (item.area === "skills") {
+    return {
+      scope: item.scope,
+      area: item.area,
+      claudePath: item.claudePath ? dirname(item.claudePath) : "",
+      codexPath: item.codexPath ? dirname(item.codexPath) : "",
+    };
+  }
+  return {
+    scope: item.scope,
+    area: item.area,
+    claudePath: item.claudePath,
+    codexPath: item.codexPath,
+  };
 }
 
 function filterBoardInventory(items, selectors) {
@@ -354,6 +383,7 @@ function firstPath(pathList, fallback) {
 function normalizeBoardOverlays(entries = []) {
   const overlays = [];
   for (const entry of entries) {
+    if (!BOARD_AREAS.has(entry.area)) continue;
     pushBoardOverlays(overlays, entry, entry.conflicts, "conflict");
     pushBoardOverlays(overlays, entry, entry.missingInCodex, "claude-only");
     pushBoardOverlays(overlays, entry, entry.missingInClaude, "codex-only");
@@ -418,20 +448,23 @@ function writeBoardFile(html) {
 
 function boardFilePath() {
   const stamp = new Date().toISOString().replaceAll(":", "-");
-  return `${home}/.ai-config-sync-manager/board/${stamp}.html`;
+  return `${home}/.ai-config-sync-manager/board/${stamp}-${process.pid}.html`;
 }
 
 function openInBrowser(path) {
   try {
-    const opener =
-      process.platform === "darwin"
-        ? "open"
-        : process.platform === "win32"
-          ? 'start ""'
-          : "xdg-open";
-    execSync(`${opener} ${shellQuote(path)}`, {
-      shell: process.platform === "win32" ? "cmd.exe" : undefined,
-    });
+    // Fire-and-forget: a detached, unref'd child can't hang the CLI if the opener never returns.
+    const child =
+      process.platform === "win32"
+        ? spawn("cmd.exe", ["/c", "start", "", path], { detached: true, stdio: "ignore" })
+        : spawn(process.platform === "darwin" ? "open" : "xdg-open", [path], {
+            detached: true,
+            stdio: "ignore",
+          });
+    // spawn reports a missing opener via an async 'error' event, not a throw; swallow it so a
+    // headless host without xdg-open cannot crash the CLI after the board file is already written.
+    child.on("error", () => {});
+    child.unref();
   } catch {
     // Path already printed; opening is best-effort.
   }

--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -198,13 +198,15 @@ function parseStatus(argv) {
 
 function parseBoard(argv) {
   let scopes = ["global", "project"];
-  let open = false;
+  let open = true;
   const selectors = emptySelectors();
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === "--open") {
       open = true;
+    } else if (token === "--no-open") {
+      open = false;
     } else if (token === "--scope") {
       scopes = parseScopes(argv[index + 1], true);
       index += 1;
@@ -8384,12 +8386,14 @@ Options:
   --scope global|project|all     Limit board scope
   --include area[:item][,...]    Include only selected areas or items
   --exclude area[:item][,...]    Exclude selected areas or items
-  --open                         Open the generated board in the default browser
+  --no-open                      Only write the file; do not open a browser
   -h, --help                     Show board help
+
+The board opens in the default browser by default; pass --no-open to skip it.
 
 Examples:
   ai-config-sync board
-  ai-config-sync board --scope global --open`);
+  ai-config-sync board --scope global --no-open`);
 }
 
 function printSyncHelp() {

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -7224,7 +7224,7 @@ test("board writes a self-contained HTML file listing planted skills", () => {
   mkdirSync(join(fixture.project, ".claude/skills/beta"), { recursive: true });
   writeFileSync(join(fixture.project, ".claude/skills/beta/SKILL.md"), "# beta\n");
 
-  const output = runCli(fixture, ["board", "--scope", "project"]);
+  const output = runCli(fixture, ["board", "--scope", "project", "--no-open"]);
   const boardPath = boardWrittenPath(output);
   assert.ok(existsSync(boardPath), "board file should exist on disk");
 
@@ -7239,7 +7239,7 @@ test("board marks a skill present on only one host as claude-only", () => {
   writeFileSync(join(fixture.project, ".claude/skills/beta/SKILL.md"), "# beta\n");
 
   const html = readFileSync(
-    boardWrittenPath(runCli(fixture, ["board", "--scope", "project"])),
+    boardWrittenPath(runCli(fixture, ["board", "--scope", "project", "--no-open"])),
     "utf8"
   );
   assert.match(html, /beta/);
@@ -7257,7 +7257,9 @@ test("board --include agents omits skills from the inventory", () => {
   );
 
   const html = readFileSync(
-    boardWrittenPath(runCli(fixture, ["board", "--scope", "project", "--include", "agents"])),
+    boardWrittenPath(
+      runCli(fixture, ["board", "--scope", "project", "--include", "agents", "--no-open"])
+    ),
     "utf8"
   );
   assert.match(html, /myagent/);

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -7266,6 +7266,96 @@ test("board --include agents omits skills from the inventory", () => {
   assert.doesNotMatch(html, /gamma/);
 });
 
+test("board omits permissions and plugins entries that fall outside its inventory areas", () => {
+  const fixture = createFixture();
+  writeJson(join(fixture.project, ".claude/settings.json"), {
+    permissions: { allow: ["WebSearch"] },
+  });
+  mkdirSync(join(fixture.project, ".codex"), { recursive: true });
+  writeFileSync(join(fixture.project, ".codex/config.toml"), "");
+
+  const html = readFileSync(
+    boardWrittenPath(runCli(fixture, ["board", "--scope", "project", "--no-open"])),
+    "utf8"
+  );
+  assert.doesNotMatch(html, /data-area="permissions"/);
+  assert.doesNotMatch(html, /data-area="plugins"/);
+  assert.doesNotMatch(html, /WebSearch/);
+});
+
+test("board drops a status-ignored skill instead of showing it as in-sync", () => {
+  const fixture = createFixture();
+  writeSkillManifest(
+    join(fixture.project, ".claude/skills/hushed"),
+    "claude",
+    "# hushed\nclaude\n"
+  );
+  writeSkillManifest(join(fixture.project, ".agents/skills/hushed"), "codex", "# hushed\ncodex\n");
+  writeJson(join(fixture.project, ".ai-config-sync-manager/status-ignore.json"), {
+    version: 1,
+    exclude: [{ scope: "project", area: "skills", item: "hushed" }],
+  });
+
+  const html = readFileSync(
+    boardWrittenPath(runCli(fixture, ["board", "--scope", "project", "--no-open"])),
+    "utf8"
+  );
+  assert.doesNotMatch(html, /hushed/);
+});
+
+test("board honors a path-form skills ignore rule targeting the SKILL.md file", () => {
+  const fixture = createFixture();
+  writeSkillManifest(
+    join(fixture.project, ".claude/skills/pathhush"),
+    "claude",
+    "# pathhush\nclaude\n"
+  );
+  writeSkillManifest(
+    join(fixture.project, ".agents/skills/pathhush"),
+    "codex",
+    "# pathhush\ncodex\n"
+  );
+  writeJson(join(fixture.project, ".ai-config-sync-manager/status-ignore.json"), {
+    version: 1,
+    exclude: [".claude/skills/pathhush/SKILL.md"],
+  });
+
+  const html = readFileSync(
+    boardWrittenPath(runCli(fixture, ["board", "--scope", "project", "--no-open"])),
+    "utf8"
+  );
+  assert.doesNotMatch(html, /pathhush/);
+});
+
+test("board file name carries a pid suffix so same-millisecond runs cannot collide", () => {
+  const fixture = createFixture();
+  mkdirSync(join(fixture.project, ".claude/skills/solo"), { recursive: true });
+  writeFileSync(join(fixture.project, ".claude/skills/solo/SKILL.md"), "# solo\n");
+
+  const boardPath = boardWrittenPath(runCli(fixture, ["board", "--scope", "project", "--no-open"]));
+  assert.match(boardPath, /Z-\d+\.html$/);
+});
+
+test("openInBrowser launches a detached, unref'd child with an async error handler so a stalled or missing opener cannot hang or crash the CLI", () => {
+  const source = readFileSync(cliPath, "utf8");
+  const start = source.indexOf("function openInBrowser");
+  const fn = source.slice(start, source.indexOf("\n}\n", start));
+  assert.match(fn, /spawn\(/);
+  assert.match(fn, /detached: true/);
+  assert.match(fn, /\.unref\(\)/);
+  assert.match(fn, /\.on\("error"/);
+  assert.doesNotMatch(fn, /execSync/);
+});
+
+test("board default open exits cleanly when the opener binary is absent from PATH", () => {
+  const fixture = createFixture();
+  mkdirSync(join(fixture.project, ".claude/skills/solo"), { recursive: true });
+  writeFileSync(join(fixture.project, ".claude/skills/solo/SKILL.md"), "# solo\n");
+
+  const output = runCli(fixture, ["board", "--scope", "project"], undefined, { PATH: "" });
+  assert.match(output, /^Board written to: /m);
+});
+
 test("board rejects an unknown option", () => {
   const fixture = createFixture();
   assert.throws(


### PR DESCRIPTION
## Summary

Makes `ai-config-sync board` open in the browser by default. Previously it only wrote the HTML file and left the user to find the path; opening was opt-in behind `--open`. Now the board opens right after it is written, and `--no-open` is available for scripts and CI that only want the file.

`--open` is still accepted (now a no-op) for backward compatibility.

## Changes

- `parseBoard`: default `open` to `true`, add `--no-open` to suppress.
- Board help + README updated (also corrects the color legend to match the current UI: blue = Claude only, purple = Codex only, and notes the per-area tabs and agent harness grouping).
- Board integration tests pass `--no-open` so the suite never launches a browser.

## Testing

- `npm test` → **354 pass / 0 fail**.
- Verified live: `board` opens the browser; `board --no-open` only writes the file.
