### PR TITLE
docs: surface the board in the README and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Ai-config-sync-manager
 
+## v0.1.8 (unreleased)
+
+### 🚀 Features
+
+- **board**: add an HTML inventory board of both hosts colored by sync status (#35, #36). A new read-only `board` subcommand renders every skill, agent, hook, and MCP server from Claude and Codex into a single self-contained HTML page (no external requests, zero runtime deps), reusing the existing `status` engine for diff data. Items split into per-area tabs and are colored by sync state — green in-sync, red conflict, blue Claude-only, purple Codex-only, amber unsupported — with agents grouped under their harness (the `agents/` subfolder). A filter box narrows by name, description, or harness. The board opens in the default browser by default (`--no-open` to skip). The renderer is a pure module (`bin/util/board-html.mjs`); the CLI normalizes the engine's diff shape into an overlay DTO so the renderer never reaches into engine internals. Overlays are restricted to the four inventoried areas and honor status-ignore rules, so the board never contradicts `status`; the browser opener is a detached fire-and-forget `spawn` (with a no-op error listener) so a missing or wedged opener never blocks or crashes the CLI.
+
 ## v0.1.7 (2026-07-12)
 
 ### 🛠 Chore

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@
 - **Prose-level token rewriting** — Claude-only tokens (`Read`, `Bash`, `TaskCreate`, headless `claude -p`) and Codex-only tokens (`spawn_agent`, `codex exec`) auto-translate across hosts and round-trip back.
 - **Zero runtime dependencies** — single ESM file, Node built-ins only.
 - **Thin host plugins** — `/config-manager:*` for Claude, `config-manager-*` for Codex.
+- **Visual inventory board** — `board` renders a self-contained HTML page of every skill, agent, hook, and MCP server on both hosts, colored by sync status (in-sync / conflict / one-host-only) and grouped into per-area tabs and by agent harness. [Jump to the board →](#board)
+
+<p align="center">
+  <a href="#board"><img src="https://raw.githubusercontent.com/slash9494/ai-config-sync-manager/main/assets/board_preview.png" alt="ai-config-sync board — inventory of agents, skills, mcp, and hooks colored by sync status" width="100%" /></a>
+</p>
 
 ## Why this exists
 
@@ -72,7 +77,7 @@ ai-config-sync sync --apply      # apply with automatic backups
 
 | Category | Sections |
 | --- | --- |
-| **Commands** | [Bundled CLI](#bundled-cli) · [Host plugin commands](#host-plugin-commands) · [Flags](#flags) |
+| **Commands** | [Bundled CLI](#bundled-cli) · [Host plugin commands](#host-plugin-commands) · [Flags](#flags) · [Board](#board) |
 | **Workflow** | [Selector syntax](#selector-syntax) · [Ignore rules](#ignore-rules) · [Sync direction](#sync-direction) · [Scopes](#scopes) |
 | **Safety** | [Safety defaults](#safety-defaults) · [Risk levels](#risk-levels) · [Retention](#retention) |
 | **Mapping** | [Native mapping](#native-mapping-claude--codex) · [Areas](#areas) · [Paraphrase](#paraphrase) · [Hidden markers](#hidden-markers) · [Unsupported](#unsupported) |
@@ -153,9 +158,7 @@ ai-config-sync status --scope project --tree --include skills:code-writer
 
 ### `board`
 
-Renders a self-contained HTML inventory board — every skill, agent, hook, and MCP server on both hosts, split into per-area tabs, colored by sync status: green = in sync, red = conflict, blue = Claude only, purple = Codex only, amber = unsupported. Agents are grouped under their harness (subfolder) where they have one. Type in the filter box to narrow rows; click a row for the full description, paths, and status detail. The file is written to `~/.ai-config-sync-manager/board/` with no external requests, so it works offline, and opens in your default browser automatically (pass `--no-open` to skip).
-
-<img src="https://raw.githubusercontent.com/slash9494/ai-config-sync-manager/main/assets/board_preview.png" alt="ai-config-sync board — inventory of agents, skills, mcp, and hooks colored by sync status" width="100%" />
+Renders a self-contained HTML inventory board — every skill, agent, hook, and MCP server on both hosts, split into per-area tabs, colored by sync status: green = in sync, red = conflict, blue = Claude only, purple = Codex only, amber = unsupported. Agents are grouped under their harness (subfolder) where they have one. Type in the filter box to narrow rows; click a row for the full description, paths, and status detail. The file is written to `~/.ai-config-sync-manager/board/` with no external requests, so it works offline, and opens in your default browser automatically (pass `--no-open` to skip). ([Screenshot at the top](#highlights).)
 
 | Flag | Description |
 | --- | --- |


### PR DESCRIPTION
Pull the board screenshot up to just under Highlights so first-time readers see the product on arrival (it was buried in the board section). Adds a Highlights bullet, a Table-of-Contents entry, and a v0.1.8 changelog entry for the board subcommand. Docs only — no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documented the new read-only `board` command, which provides a self-contained visual inventory of skills, agents, hooks, and MCP servers.
  * Added details about status-based color coding, per-area tabs, and the `--no-open` option.

* **Documentation**
  * Improved board feature discoverability with a Highlights entry, preview image, and Table of Contents link.
  * Updated the board command documentation to reference the shared preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->