### PR TITLE
ci(compat): move the drift schedule so the local notifier lands after it

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -2,8 +2,9 @@ name: Upstream compatibility snapshot
 
 "on":
   schedule:
-    # Fridays at 03:17 UTC — aligned with US Thu evening PT deploy.
-    - cron: "17 3 * * 5"
+    # Fridays at 13:17 UTC (22:17 KST). The local notifier (com.aiconfigsync.compat) fires 4h43m
+    # later; GitHub has started this schedule up to 3h38m late, which a 30min gap never survived.
+    - cron: "17 13 * * 5"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

The macOS notifier `com.aiconfigsync.compat` was scheduled 30 minutes after this workflow's nominal cron time. GitHub has never actually started the schedule that promptly:

| Run | Nominal | Actual start (UTC) | Late by |
| --- | --- | --- | --- |
| 2026-07-24 | 03:17 | 06:04 | 2h47m |
| 2026-07-17 | 03:17 | 05:56 | 2h39m |
| 2026-07-10 | 03:17 | 06:55 | 3h38m |
| 2026-07-03 | 03:17 | 04:31 | 1h14m |
| 2026-06-19 | 03:17 | 04:57 | 1h40m |

So the notifier ran at 03:47 UTC every week, found no drift PR, and exited as a no-op. PR #33 sat open and unreviewed for a week with no notification.

## What

- Workflow cron `17 3 * * 5` → `17 13 * * 5` (Friday 22:17 KST).
- The plist lives outside this repo (`~/Library/LaunchAgents/com.aiconfigsync.compat.plist`) and was moved to Saturday 03:00 KST. That is a **4h43m** gap — an hour clear of the worst delay observed above.

The `:17` minute is kept on purpose: schedules on the hour queue behind everyone else's and drift further.

## Verification

- `yaml.safe_load` parses the workflow; `schedule` reads `[{'cron': '17 13 * * 5'}]`.
- `plutil -lint` passes; `launchctl print gui/$UID/com.aiconfigsync.compat` reports `Minute => 0, Hour => 3, Weekday => 6`. Per `man launchd.plist`, "0 and 7 are Sunday", so 6 is Saturday.
- Timezone math checked against a concrete date: cron fires Fri 2026-07-31 13:17 UTC (22:17 KST); the notifier fires Fri 18:00 UTC (Sat 03:00 KST).
- The real check is next Friday: the workflow should start between 13:17 and ~17:00 UTC, and the notifier should find the PR at 18:00 UTC.

## Not covered here

`scripts/compat-review-cron.sh` treats a failed `gh pr list` the same as "no PR" — the 2026-07-24 log shows `error connecting to api.github.com` followed by `no open drift PR — no-op`. Timing was the primary cause, but that path can still swallow a real failure silently. Left for a separate change.