### PR TITLE
fix: close the three findings from the PR #33 compat review

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -354,71 +354,9 @@ jobs:
               fi
             } >> .upstream-compat/body.md
           fi
-          # Enum drift: enum-bearing keys the runtime hardcodes. Members added/removed AND hardcoded values stale.
-          extract_enum_members() {
-            local file="$1" key="$2"
-            [ -f "$file" ] || return 0
-            jq -r --arg k "$key" '[.properties[$k].oneOf[]?.enum[]?, .properties[$k].enum[]?] | unique | .[]' "$file" 2>/dev/null | sort -u
-          }
-          extract_enum_members_head() {
-            local path="$1" key="$2"
-            git show "HEAD:$path" 2>/dev/null | jq -r --arg k "$key" '[.properties[$k].oneOf[]?.enum[]?, .properties[$k].enum[]?] | unique | .[]' 2>/dev/null | sort -u || true
-          }
-          # Codex enum-bearing keys + the value the runtime hardcodes.
-          codex_enum_watch="snapshots/codex/config-schema.json:sandbox_mode:workspace-write
-          snapshots/codex/config-schema.json:approval_policy:on-request
-          snapshots/codex/config-schema.json:web_search:live"
-          codex_enum_drift=""
-          while IFS=: read -r file key val; do
-            file=$(echo "$file" | sed 's/^ *//')
-            [ -z "${file:-}" ] && continue
-            curr=$(extract_enum_members "$file" "$key")
-            prev=$(extract_enum_members_head "$file" "$key")
-            added=$(comm -23 <(printf '%s\n' "$curr") <(printf '%s\n' "$prev") | sed '/^$/d' | tr '\n' ' ' | sed 's/ *$//' || true)
-            removed=$(comm -13 <(printf '%s\n' "$curr") <(printf '%s\n' "$prev") | sed '/^$/d' | tr '\n' ' ' | sed 's/ *$//' || true)
-            if [ -n "$added" ] || [ -n "$removed" ]; then
-              codex_enum_drift="${codex_enum_drift}- \`${key}\` enum changed"$'\n'
-              [ -n "$added" ] && codex_enum_drift="${codex_enum_drift}  - added: ${added}"$'\n'
-              [ -n "$removed" ] && codex_enum_drift="${codex_enum_drift}  - removed: ${removed}"$'\n'
-            fi
-            if [ -n "$curr" ] && ! printf '%s\n' "$curr" | grep -qx "$val"; then
-              codex_enum_drift="${codex_enum_drift}- **STALE HARDCODED** \`${key} = \"${val}\"\` no longer in schema enum (runtime will write an invalid value)"$'\n'
-            fi
-          done <<< "$codex_enum_watch"
-          # Claude hardcoded hook event names: properties.hooks.properties.<EventName>
-          claude_hook_events_curr=$(jq -r '.properties.hooks.properties // {} | keys[]' snapshots/claude/settings-schema.json 2>/dev/null | sort -u)
-          claude_hook_events_prev=$(git show HEAD:snapshots/claude/settings-schema.json 2>/dev/null | jq -r '.properties.hooks.properties // {} | keys[]' 2>/dev/null | sort -u || true)
-          claude_hook_added=$(comm -23 <(printf '%s\n' "$claude_hook_events_curr") <(printf '%s\n' "$claude_hook_events_prev") | sed '/^$/d' | tr '\n' ' ' | sed 's/ *$//' || true)
-          claude_hook_removed=$(comm -13 <(printf '%s\n' "$claude_hook_events_curr") <(printf '%s\n' "$claude_hook_events_prev") | sed '/^$/d' | tr '\n' ' ' | sed 's/ *$//' || true)
-          claude_enum_drift=""
-          if [ -n "$claude_hook_added" ] || [ -n "$claude_hook_removed" ]; then
-            claude_enum_drift="${claude_enum_drift}- \`hooks\` event names changed"$'\n'
-            [ -n "$claude_hook_added" ] && claude_enum_drift="${claude_enum_drift}  - added: ${claude_hook_added}"$'\n'
-            [ -n "$claude_hook_removed" ] && claude_enum_drift="${claude_enum_drift}  - removed: ${claude_hook_removed}"$'\n'
-          fi
-          for ev in PreToolUse PostToolUse SessionStart UserPromptSubmit; do
-            if [ -n "$claude_hook_events_curr" ] && ! printf '%s\n' "$claude_hook_events_curr" | grep -qx "$ev"; then
-              claude_enum_drift="${claude_enum_drift}- **STALE HARDCODED** hook event \`${ev}\` no longer in \`hooks.properties\` (runtime writes a hook the host will not fire)"$'\n'
-            fi
-          done
-          if [ -n "${claude_enum_drift:-}" ] || [ -n "${codex_enum_drift:-}" ]; then
-            {
-              echo
-              echo "## Compat scan — enum drift on watched keys"
-              echo
-              echo "Enum members on keys the runtime hardcodes. STALE HARDCODED means \`bin/ai-config-sync.mjs\` will emit a value the new schema rejects — runtime fix required, not just a checklist."
-              if [ -n "${claude_enum_drift:-}" ]; then
-                echo
-                echo "### Claude"
-                printf '%s\n' "$claude_enum_drift"
-              fi
-              if [ -n "${codex_enum_drift:-}" ]; then
-                echo
-                echo "### Codex"
-                printf '%s\n' "$codex_enum_drift"
-              fi
-            } >> .upstream-compat/body.md
-          fi
+          # Enum drift on keys the runtime hardcodes. The schema states them as $ref indirections,
+          # so resolving them needs a real walk, not a flat read of the property's own .enum.
+          node scripts/detect-enum-drift.mjs >> .upstream-compat/body.md || true
           # Model tiers live in agents-map.json, never in the settings/config schema — detect from changelog/releases prose.
           node scripts/detect-model-drift.mjs >> .upstream-compat/body.md || true
           # Raw diff goes LAST, capped to the remaining GitHub PR-body budget (hard limit 65536).

--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -6776,7 +6776,8 @@ function enumerateCodexAgents(dir) {
 function canonicalAgentName(rawName, fallbackStem) {
   const candidate = typeof rawName === "string" ? rawName.trim() : "";
   const source = candidate || fallbackStem || "";
-  return source.replace(/\//g, "-");
+  // Claude rejects ":" in agent names since CLI 2.1.218 — it is reserved for plugin namespacing.
+  return source.replace(/[/:]/g, "-");
 }
 
 function agentsEquivalent(claudeAgent, codexAgent, entry, item, rules) {
@@ -6988,7 +6989,8 @@ function mapAgentToClaude(codex, options = {}) {
   );
   recordVocabFindings(options.callArchive, lintHostVocab(body, "claude"), "codex", "claude");
   const frontmatter = {
-    name: codex.name ?? "",
+    // Same canonicalization the file name gets — a raw Codex name can carry characters Claude rejects.
+    name: canonicalAgentName(codex.name, options.fallbackName),
     description: codex.description ?? "",
     model: aliases[codex.model] ?? codex.model ?? "",
   };
@@ -7062,15 +7064,14 @@ function modelTiers() {
 function modelAliasMap(from, to) {
   const aliases = {};
   for (const tier of modelTiers()) {
-    const sourceAlias = tier?.[from]?.alias;
     const targetAlias = tier?.[to]?.alias;
-    if (
-      typeof sourceAlias === "string" &&
-      sourceAlias &&
-      typeof targetAlias === "string" &&
-      targetAlias
-    ) {
-      aliases[sourceAlias] = targetAlias;
+    if (typeof targetAlias !== "string" || !targetAlias) continue;
+    const sourceTerms = Array.isArray(tier?.[from]?.terms) ? tier[from].terms : [];
+    // terms carry retired ids and vendor-tagged variants, so they map too; tiers run strongest
+    // first and the earlier one keeps any token two tiers happen to share.
+    for (const token of [tier?.[from]?.alias, ...sourceTerms]) {
+      if (typeof token !== "string" || !token || token in aliases) continue;
+      aliases[token] = targetAlias;
     }
   }
   return aliases;

--- a/docs/customizing-rules.md
+++ b/docs/customizing-rules.md
@@ -298,8 +298,8 @@ Manages agent field mappings and model tier aliases. Use this when you want to a
           "terms": ["sonnet(latest)", "Claude Sonnet", "Sonnet", "standard model"]
         },
         "codex": {
-          "alias": "gpt-5.4",
-          "terms": ["GPT-5.4", "standard model"]
+          "alias": "gpt-5.6-luna",
+          "terms": ["GPT-5.6 Luna", "standard model"]
         }
       }
     ]
@@ -307,7 +307,7 @@ Manages agent field mappings and model tier aliases. Use this when you want to a
 }
 ```
 
-The `latest-frontier-model` and `small-fast-model` tiers and the `fields` array are kept as the bundle ships them.
+The `mythos-class-model`, `latest-frontier-model`, and `small-fast-model` tiers and the `fields` array are kept as the bundle ships them.
 
 **Recipe: add a new model tier**
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -195,9 +195,12 @@ Hook, MCP, and web access vocabulary used in text instructions.
 
 Model alias rules come from `rules/agents-map.json` `models.tiers` rather than the terminology map.
 
-- `latest-frontier-model` — `opus` ↔ `gpt-5.5`
-- `balanced-model` — `sonnet` ↔ `gpt-5.4`
+- `mythos-class-model` — `fable` ↔ `gpt-5.6-sol`
+- `latest-frontier-model` — `opus` ↔ `gpt-5.6-terra`
+- `balanced-model` — `sonnet` ↔ `gpt-5.6-luna`
 - `small-fast-model` — `haiku` ↔ `gpt-5.4-mini`
+
+Each tier's `terms` are also accepted as model values, so retired ids (`gpt-5.4`, `gpt-5.5`) and vendor-tagged variants (`gpt-5.3-codex`, `gpt-5.1-codex-max`) convert to the tier's alias instead of passing through unmapped. Tiers are ordered strongest first and the earlier tier wins any token two of them share.
 
 ## Paraphrase
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "refresh:cache": "node scripts/refresh-cache.mjs",
     "snapshot:upstream": "node scripts/snapshot-upstream.mjs",
     "snapshot:model-drift": "node scripts/detect-model-drift.mjs",
+    "snapshot:enum-drift": "node scripts/detect-enum-drift.mjs",
     "test": "node --test tests/*.test.mjs tests/integration/codex-to-claude/*.test.mjs",
     "test:manual:reset": "tests/integration/manual-codex-to-claude/scripts/reset.sh",
     "test:manual:run": "tests/integration/manual-codex-to-claude/scripts/run-cases.sh",

--- a/rules/agents-map.json
+++ b/rules/agents-map.json
@@ -22,17 +22,34 @@
     }
   },
   "models": {
-    "description": "Single source of truth for model mapping. `alias` is the bare frontmatter token used by agent-frontmatter mapping. `terms` is the ordered synonym list for free-text terminology mapping (first term is the canonical replacement target).",
+    "description": "Single source of truth for model mapping. `alias` is the canonical token written into converted frontmatter and prose. `terms` are additional accepted spellings of the same tier — every one is also a recognized frontmatter model value, which is how retired ids and vendor-tagged variants (gpt-5.3-codex, gpt-5.1-codex-max) still convert instead of passing through unmapped. Tiers are ordered strongest first; on a duplicate token the earlier tier wins.",
     "tiers": [
+      {
+        "id": "mythos-class-model",
+        "claude": {
+          "alias": "fable",
+          "terms": ["fable(latest)", "Claude Fable 5", "Fable 5"]
+        },
+        "codex": {
+          "alias": "gpt-5.6-sol",
+          "terms": ["gpt-5.6", "GPT-5.6 Sol", "GPT-5.6-Sol"]
+        }
+      },
       {
         "id": "latest-frontier-model",
         "claude": {
           "alias": "opus",
-          "terms": ["opus4.8(latest)", "opus 4.8 latest", "Claude Opus 4.8", "Opus 4.8", "Opus"]
+          "terms": ["opus(latest)", "Claude Opus 5", "Opus 5", "Opus"]
         },
         "codex": {
-          "alias": "gpt-5.6",
-          "terms": ["gpt5.6(latest)", "gpt-5.6 latest", "GPT-5.6", "GPT 5.6"]
+          "alias": "gpt-5.6-terra",
+          "terms": [
+            "gpt-5.5",
+            "gpt-5.3-codex",
+            "gpt-5.1-codex-max",
+            "GPT-5.6 Terra",
+            "GPT-5.6-Terra"
+          ]
         }
       },
       {
@@ -42,19 +59,19 @@
           "terms": ["sonnet(latest)", "Claude Sonnet 5", "Claude Sonnet", "Sonnet 5", "Sonnet"]
         },
         "codex": {
-          "alias": "gpt-5.4",
-          "terms": ["GPT-5.4"]
+          "alias": "gpt-5.6-luna",
+          "terms": ["gpt-5.4", "gpt-5.1-codex-mini", "GPT-5.6 Luna", "GPT-5.6-Luna", "GPT-5.4"]
         }
       },
       {
         "id": "small-fast-model",
         "claude": {
           "alias": "haiku",
-          "terms": ["haiku(latest)", "Claude Haiku", "Haiku"]
+          "terms": ["haiku(latest)", "Claude Haiku 4.5", "Claude Haiku", "Haiku 4.5", "Haiku"]
         },
         "codex": {
           "alias": "gpt-5.4-mini",
-          "terms": ["GPT-5.4-Mini"]
+          "terms": ["gpt-5.4-nano", "GPT-5.4-Mini"]
         }
       }
     ]

--- a/scripts/detect-enum-drift.mjs
+++ b/scripts/detect-enum-drift.mjs
@@ -128,8 +128,11 @@ export function renderSection(claudeFindings, codexFindings) {
 function readSchema(path) {
   try {
     return JSON.parse(readFileSync(path, "utf8"));
-  } catch {
-    return {};
+  } catch (err) {
+    // An empty object would read as "every watched key was removed upstream" and invent a KEY GONE
+    // report out of a local read failure.
+    process.stderr.write(`detect-enum-drift: cannot read ${path}: ${err.message}\n`);
+    return null;
   }
 }
 
@@ -144,11 +147,11 @@ function readSchemaAtHead(path) {
 }
 
 function main() {
-  const codexHead = readSchemaAtHead(CODEX_SCHEMA);
-  const claudeHead = readSchemaAtHead(CLAUDE_SCHEMA);
+  const claude = [readSchema(CLAUDE_SCHEMA), readSchemaAtHead(CLAUDE_SCHEMA)];
+  const codex = [readSchema(CODEX_SCHEMA), readSchemaAtHead(CODEX_SCHEMA)];
   const section = renderSection(
-    claudeHead ? findClaudeHookDrift(readSchema(CLAUDE_SCHEMA), claudeHead) : [],
-    codexHead ? findCodexEnumDrift(readSchema(CODEX_SCHEMA), codexHead) : []
+    claude.every(Boolean) ? findClaudeHookDrift(...claude) : [],
+    codex.every(Boolean) ? findCodexEnumDrift(...codex) : []
   );
   if (section) process.stdout.write(section);
 }

--- a/scripts/detect-enum-drift.mjs
+++ b/scripts/detect-enum-drift.mjs
@@ -1,0 +1,158 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const CODEX_SCHEMA = "snapshots/codex/config-schema.json";
+const CLAUDE_SCHEMA = "snapshots/claude/settings-schema.json";
+
+// Watched key -> the value bin/ai-config-sync.mjs writes for it.
+const CODEX_WATCH = {
+  sandbox_mode: "workspace-write",
+  approval_policy: "on-request",
+  web_search: "live",
+};
+const CLAUDE_HOOK_EVENTS = ["PreToolUse", "PostToolUse", "SessionStart", "UserPromptSubmit"];
+
+const REF_PREFIX = "#/definitions/";
+const MAX_REF_DEPTH = 8;
+
+// Watched keys are $ref indirections — `{"allOf":[{"$ref":"#/definitions/SandboxMode"}]}` — so
+// reading `.enum` off the property yields nothing and every comparison silently passes. The members
+// live on the definition, and some definitions spell them as oneOf branches of one enum each.
+export function resolveEnumMembers(schema, key) {
+  const root = schema?.properties?.[key];
+  if (!root) return [];
+  const members = new Set();
+  const visit = (node, depth) => {
+    if (!node || typeof node !== "object" || depth > MAX_REF_DEPTH) return;
+    for (const value of Array.isArray(node.enum) ? node.enum : []) members.add(value);
+    for (const branch of ["oneOf", "anyOf", "allOf"]) {
+      for (const child of Array.isArray(node[branch]) ? node[branch] : []) visit(child, depth + 1);
+    }
+    const ref = node.$ref;
+    if (typeof ref === "string" && ref.startsWith(REF_PREFIX)) {
+      visit(schema?.definitions?.[ref.slice(REF_PREFIX.length)], depth + 1);
+    }
+  };
+  visit(root, 0);
+  return [...members].sort();
+}
+
+export function hookEventNames(schema) {
+  const events = schema?.properties?.hooks?.properties;
+  return events && typeof events === "object" ? Object.keys(events).sort() : [];
+}
+
+function memberDiff(current, previous) {
+  return {
+    added: current.filter((member) => !previous.includes(member)),
+    removed: previous.filter((member) => !current.includes(member)),
+  };
+}
+
+export function findCodexEnumDrift(current, previous, watch = CODEX_WATCH) {
+  const findings = [];
+  for (const [key, hardcoded] of Object.entries(watch)) {
+    if (!current?.properties?.[key]) {
+      findings.push({ key, missingKey: true });
+      continue;
+    }
+    const members = resolveEnumMembers(current, key);
+    const { added, removed } = memberDiff(members, resolveEnumMembers(previous, key));
+    if (added.length > 0 || removed.length > 0) findings.push({ key, added, removed });
+    if (members.length > 0 && !members.includes(hardcoded))
+      findings.push({ key, stale: hardcoded });
+  }
+  return findings;
+}
+
+export function findClaudeHookDrift(current, previous, hardcoded = CLAUDE_HOOK_EVENTS) {
+  const findings = [];
+  const events = hookEventNames(current);
+  const { added, removed } = memberDiff(events, hookEventNames(previous));
+  if (added.length > 0 || removed.length > 0) findings.push({ key: "hooks", added, removed });
+  if (events.length === 0) return findings;
+  for (const event of hardcoded) {
+    if (!events.includes(event)) findings.push({ key: "hooks", stale: event });
+  }
+  return findings;
+}
+
+function renderFinding(finding, staleLabel) {
+  if (finding.missingKey) {
+    return `- **KEY GONE** \`${finding.key}\` is no longer in the schema at all`;
+  }
+  if (finding.stale) return staleLabel(finding);
+  const lines = [`- \`${finding.key}\` enum changed`];
+  if (finding.added.length > 0) lines.push(`  - added: ${finding.added.join(" ")}`);
+  if (finding.removed.length > 0) lines.push(`  - removed: ${finding.removed.join(" ")}`);
+  return lines.join("\n");
+}
+
+export function renderSection(claudeFindings, codexFindings) {
+  if (claudeFindings.length === 0 && codexFindings.length === 0) return "";
+  const lines = [
+    "",
+    "## Compat scan — enum drift on watched keys",
+    "",
+    "Enum members on keys the runtime hardcodes. STALE HARDCODED means `bin/ai-config-sync.mjs` will emit a value the new schema rejects — runtime fix required, not just a checklist.",
+  ];
+  if (claudeFindings.length > 0) {
+    lines.push("", "### Claude");
+    for (const finding of claudeFindings) {
+      lines.push(
+        renderFinding(
+          finding,
+          (f) =>
+            `- **STALE HARDCODED** hook event \`${f.stale}\` no longer in \`hooks.properties\` (runtime writes a hook the host will not fire)`
+        )
+      );
+    }
+  }
+  if (codexFindings.length > 0) {
+    lines.push("", "### Codex");
+    for (const finding of codexFindings) {
+      lines.push(
+        renderFinding(
+          finding,
+          (f) =>
+            `- **STALE HARDCODED** \`${f.key} = "${f.stale}"\` no longer in schema enum (runtime will write an invalid value)`
+        )
+      );
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function readSchema(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function readSchemaAtHead(path) {
+  try {
+    return JSON.parse(execFileSync("git", ["show", `HEAD:${path}`], { encoding: "utf8" }));
+  } catch (err) {
+    // A silent {} reads as "everything is new" and would report the whole enum as added.
+    process.stderr.write(`detect-enum-drift: cannot read HEAD:${path}: ${err.message}\n`);
+    return null;
+  }
+}
+
+function main() {
+  const codexHead = readSchemaAtHead(CODEX_SCHEMA);
+  const claudeHead = readSchemaAtHead(CLAUDE_SCHEMA);
+  const section = renderSection(
+    claudeHead ? findClaudeHookDrift(readSchema(CLAUDE_SCHEMA), claudeHead) : [],
+    codexHead ? findCodexEnumDrift(readSchema(CODEX_SCHEMA), codexHead) : []
+  );
+  if (section) process.stdout.write(section);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/detect-model-drift.mjs
+++ b/scripts/detect-model-drift.mjs
@@ -17,8 +17,8 @@ const PROSE_FILES = [
 // Stopwords are the inverse risk of an allowlist: a stopword that later becomes a real model name
 // silently misses it, so the lists stay tight, grounded, and HOST-SCOPED. Grammar words are never a
 // model in any position → global. Product/plan words were grounded in the "Claude <word>" slot
-// (Code appears 130×, Platform/API/Pro/Max/Desktop/Browser/Skills/Agent/Fable are Claude products,
-// plans, or an unmapped model) — but on the Codex side "Pro"/"Max" are REAL model tiers (GPT-5 Pro,
+// (Code appears 130×, Platform/API/Pro/Max/Desktop/Browser/Skills/Agent are Claude products or
+// plans) — but on the Codex side "Pro"/"Max" are REAL model tiers (GPT-5 Pro,
 // o1-pro), so applying them there would silently drop a new variant whose base tier is already known.
 // Hence product words apply to the claude patterns only. New names surface by default; cheap
 // human-review noise beats a silent miss (this is what let a tier bump slip through before).
@@ -44,7 +44,6 @@ const CLAUDE_PRODUCT_STOPWORDS = new Set([
   "browser",
   "skills",
   "agent",
-  "fable",
 ]);
 function isStopword(host, name) {
   if (!name) return false;

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -656,8 +656,8 @@ test("default status details content differs sources", () => {
 
 test("instructions status treats terminology-mapped model names as equivalent", () => {
   const fixture = createFixture();
-  writeFileSync(join(fixture.project, "CLAUDE.md"), "Use opus4.8(latest) for hard reasoning.\n");
-  writeFileSync(join(fixture.project, "AGENTS.md"), "Use gpt-5.6 for hard reasoning.\n");
+  writeFileSync(join(fixture.project, "CLAUDE.md"), "Use opus(latest) for hard reasoning.\n");
+  writeFileSync(join(fixture.project, "AGENTS.md"), "Use gpt-5.6-terra for hard reasoning.\n");
 
   const report = JSON.parse(
     runCli(fixture, ["status", "--scope", "project", "--include", "instructions", "--json"])
@@ -812,16 +812,16 @@ test("status reports same-name skill content drift as a manual conflict", () => 
     /apply: ai-config-sync sync --scope project --include skills:review --apply/
   );
   assert.match(output, /- Codex current L2: Codex version/);
-  assert.match(output, /\+ After apply from Claude L2: model: gpt-5\.6/);
+  assert.match(output, /\+ After apply from Claude L2: model: gpt-5\.6-terra/);
   assert.match(
     readFileSync(statusDetailPath(output), "utf8"),
-    /\+ After apply from Claude L2: model: gpt-5\.6/
+    /\+ After apply from Claude L2: model: gpt-5\.6-terra/
   );
 });
 
 test("status treats skill as equivalent when transform and override jointly equalize content", () => {
   // Verifies skillDirsEquivalent's transform+override combined-path: SKILL.md
-  // diverges in BOTH a model token (opus <-> gpt-5.6, closed by terminology
+  // diverges in BOTH a model token (opus <-> gpt-5.6-terra, closed by terminology
   // transform) AND a free-prose line (closed only by an active paraphrase
   // override). Neither path alone makes them equal, but applied together they
   // must — otherwise the skill surfaces as a manual conflict.
@@ -834,11 +834,11 @@ test("status treats skill as equivalent when transform and override jointly equa
   mkdirSync(claudeSkill, { recursive: true });
   mkdirSync(codexSkill, { recursive: true });
 
-  // opus4.8(latest) <-> gpt-5.6 is a baked-in terminology mapping (agents-map.json
+  // opus(latest) <-> gpt-5.6-terra is a baked-in terminology mapping (agents-map.json
   // models.tiers, latest-frontier-model). Used here to force one-directional
   // transform equivalence for the model-token line.
-  const claudeBody = "# Jointly\nUse opus4.8(latest) for hard reasoning.\nRead the docs.\n";
-  const codexBody = "# Jointly\nUse gpt-5.6 for hard reasoning.\nInspect the docs.\n";
+  const claudeBody = "# Jointly\nUse opus(latest) for hard reasoning.\nRead the docs.\n";
+  const codexBody = "# Jointly\nUse gpt-5.6-terra for hard reasoning.\nInspect the docs.\n";
   writeFileSync(join(claudeSkill, "SKILL.md"), claudeBody);
   writeFileSync(join(codexSkill, "SKILL.md"), codexBody);
 
@@ -886,7 +886,7 @@ test("status treats skill differing only by model alias as equivalent (no phanto
   );
   writeFileSync(
     join(fixture.project, ".agents/skills/aliased/SKILL.md"),
-    "---\nname: aliased\nmodel: gpt-5.6\n---\n# Aliased\nShared body.\n"
+    "---\nname: aliased\nmodel: gpt-5.6-terra\n---\n# Aliased\nShared body.\n"
   );
 
   const report = JSON.parse(
@@ -899,7 +899,7 @@ test("status treats skill differing by model alias plus a term-masked line as eq
   // Regression for #10 sibling path: maskedSkillContentHash transforms to the
   // host-native model alias but never folds it back to canonical the way
   // skillContentHash does. When a skill needs BOTH a term ignore rule (to mask a
-  // diverging prose line) AND the model fold, the masked hash ends on gpt-5.6 vs
+  // diverging prose line) AND the model fold, the masked hash ends on gpt-5.6-terra vs
   // canonical opus and the skill surfaces as a phantom manual conflict.
   const fixture = createFixture();
   writeSkillManifest(
@@ -919,7 +919,9 @@ test("status treats skill differing by model alias plus a term-masked line as eq
   writeSkillManifest(
     join(fixture.project, ".agents/skills/masked-alias"),
     "codex",
-    ["---", "name: masked-alias", "model: gpt-5.6", "---", "# X", "common line", ""].join("\n")
+    ["---", "name: masked-alias", "model: gpt-5.6-terra", "---", "# X", "common line", ""].join(
+      "\n"
+    )
   );
   mkdirSync(join(fixture.project, ".ai-config-sync-manager"), { recursive: true });
   writeJson(join(fixture.project, ".ai-config-sync-manager/status-ignore.json"), {
@@ -937,7 +939,7 @@ test("status treats skill differing by model alias plus an override-masked line 
   // Regression for #10 sibling path: overriddenTransformedSkillContentHash layers
   // transformTextForHost over paraphrase masking but never folds the model token
   // back to canonical. A skill needing BOTH a paraphrase override (to mask a
-  // diverging prose line) AND the model fold ends on gpt-5.6 vs canonical opus,
+  // diverging prose line) AND the model fold ends on gpt-5.6-terra vs canonical opus,
   // surfacing as a phantom manual conflict even though the prose is overridden.
   const fixture = createFixture();
   const projectReal = realpathSync(fixture.project);
@@ -951,7 +953,7 @@ test("status treats skill differing by model alias plus an override-masked line 
   );
   writeFileSync(
     join(codexSkill, "SKILL.md"),
-    "---\nname: override-alias\nmodel: gpt-5.6\n---\n# X\nInspect the docs.\n"
+    "---\nname: override-alias\nmodel: gpt-5.6-terra\n---\n# X\nInspect the docs.\n"
   );
   writeJson(join(fixture.home, ".ai-config-sync-manager/rules/paraphrase-overrides.json"), {
     version: 1,
@@ -1567,7 +1569,7 @@ test("sync applies default terminology mappings to instructions", () => {
   const fixture = createFixture();
   writeFileSync(
     join(fixture.project, "CLAUDE.md"),
-    "Use CLAUDE.md with opus4.8(latest), thinking budget, and Task-tool delegation.\n"
+    "Use CLAUDE.md with opus(latest), thinking budget, and Task-tool delegation.\n"
   );
   writeFileSync(join(fixture.project, "AGENTS.md"), "old\n");
 
@@ -1585,7 +1587,7 @@ test("sync applies default terminology mappings to instructions", () => {
   assert.match(output, /Target templates: .*rules\/host-target-templates\.json/);
   assert.equal(
     agents,
-    "Use AGENTS.md with gpt-5.6, reasoning effort, and Codex spawn_agent delegation.\n"
+    "Use AGENTS.md with gpt-5.6-terra, reasoning effort, and Codex spawn_agent delegation.\n"
   );
 });
 
@@ -1708,9 +1710,9 @@ test("sync apply replaces manual skill conflicts without per-operation approval"
   assert.match(output, /Change preview:/);
   assert.match(output, /review: target will be replaced from Claude/);
   assert.match(output, /- Target current L2: Codex version/);
-  assert.match(output, /\+ After apply from Claude L2: model: gpt-5\.6/);
+  assert.match(output, /\+ After apply from Claude L2: model: gpt-5\.6-terra/);
   assert.match(output, /replaced skill review/);
-  assert.equal(skill, "# Review\nmodel: gpt-5.6\n");
+  assert.equal(skill, "# Review\nmodel: gpt-5.6-terra\n");
 });
 
 test("sync apply normalizes model alias in frontmatter when copying skill claude->codex", () => {
@@ -1725,7 +1727,7 @@ test("sync apply normalizes model alias in frontmatter when copying skill claude
   const skill = readFileSync(join(fixture.project, ".agents/skills/review/SKILL.md"), "utf8");
 
   assert.match(skill, /^---\n/);
-  assert.match(skill, /\nmodel: gpt-5\.6\n/);
+  assert.match(skill, /\nmodel: gpt-5\.6-terra\n/);
   assert.doesNotMatch(skill, /\nmodel: opus\n/);
 });
 
@@ -1734,7 +1736,7 @@ test("sync apply normalizes model alias in frontmatter when copying skill codex-
   mkdirSync(join(fixture.project, ".agents/skills/review"), { recursive: true });
   writeFileSync(
     join(fixture.project, ".agents/skills/review/SKILL.md"),
-    "---\nname: review\nmodel: gpt-5.6\n---\n# Review\n\nBody.\n"
+    "---\nname: review\nmodel: gpt-5.6-terra\n---\n# Review\n\nBody.\n"
   );
 
   runCli(fixture, [
@@ -1753,7 +1755,7 @@ test("sync apply normalizes model alias in frontmatter when copying skill codex-
 
   assert.match(skill, /^---\n/);
   assert.match(skill, /\nmodel: opus\n/);
-  assert.doesNotMatch(skill, /\nmodel: gpt-5\.6\n/);
+  assert.doesNotMatch(skill, /\nmodel: gpt-5\.6-terra\n/);
 });
 
 test("sync applies terminology mappings when copying skills", () => {
@@ -1767,7 +1769,7 @@ test("sync applies terminology mappings when copying skills", () => {
   runCli(fixture, ["sync", "--scope", "project", "--include", "skills:review", "--apply"]);
   const skill = readFileSync(join(fixture.project, ".agents/skills/review/SKILL.md"), "utf8");
 
-  assert.equal(skill, "# Review\nUse AGENTS.md with gpt-5.6.\n");
+  assert.equal(skill, "# Review\nUse AGENTS.md with gpt-5.6-terra.\n");
 });
 
 test("sync applies host target templates when copying skills", () => {
@@ -2819,7 +2821,7 @@ test("agents sync apply copies Claude agent to Codex with model alias", () => {
   assert.match(output, /Backup root: /);
   assert.match(codexFile, /^name = "sample"$/m);
   assert.match(codexFile, /^description = "Example agent"$/m);
-  assert.match(codexFile, /^model = "gpt-5\.6"$/m);
+  assert.match(codexFile, /^model = "gpt-5\.6-terra"$/m);
   assert.match(codexFile, /developer_instructions = "[^"]*Hello, agent body\./);
 });
 
@@ -2867,6 +2869,91 @@ test("agents sync apply copies Codex agent to Claude with reverse model alias", 
   assert.match(claudeFile, /^model: sonnet$/m);
   assert.match(claudeFile, /Real codex content/);
   assert.doesNotMatch(claudeFile, /Migrated from Claude agent/);
+});
+
+test("agents sync apply maps the Claude fable alias onto the Codex flagship model", () => {
+  const fixture = createFixture();
+  writeClaudeAgent(
+    join(fixture.project, ".claude/agents/sample.md"),
+    { name: "sample", description: "Example agent", model: "fable" },
+    "Hello, agent body."
+  );
+  mkdirSync(join(fixture.project, ".codex/agents"), { recursive: true });
+
+  runCli(fixture, ["sync", "--scope", "project", "--include", "agents:sample", "--apply"]);
+  const codexFile = readFileSync(join(fixture.project, ".codex/agents/sample.toml"), "utf8");
+
+  assert.match(codexFile, /^model = "gpt-5\.6-sol"$/m);
+});
+
+test("agents sync apply maps a vendor-tagged Codex model onto its Claude tier", () => {
+  const fixture = createFixture();
+  mkdirSync(join(fixture.project, ".claude/agents"), { recursive: true });
+  writeCodexAgent(join(fixture.project, ".codex/agents/sample.toml"), {
+    name: "sample",
+    description: "Example agent",
+    model: "gpt-5.3-codex",
+    developer_instructions: "Real codex content",
+  });
+
+  runCli(
+    fixture,
+    ["sync", "--scope", "project", "--include", "agents:sample", "--apply"],
+    undefined,
+    {
+      AI_CONFIG_SYNC_HOST: "codex",
+    }
+  );
+  const claudeFile = readFileSync(join(fixture.project, ".claude/agents/sample.md"), "utf8");
+
+  assert.match(claudeFile, /^model: opus$/m);
+});
+
+// gpt-5.6-luna belongs to balanced-model, declared after mythos-class-model and
+// latest-frontier-model — a later tier must not capture a token an earlier one already owns.
+test("agents sync apply resolves a shared model token to the earliest tier that claims it", () => {
+  const fixture = createFixture();
+  mkdirSync(join(fixture.project, ".claude/agents"), { recursive: true });
+  writeCodexAgent(join(fixture.project, ".codex/agents/sample.toml"), {
+    name: "sample",
+    description: "Example agent",
+    model: "gpt-5.6-luna",
+    developer_instructions: "Real codex content",
+  });
+
+  runCli(
+    fixture,
+    ["sync", "--scope", "project", "--include", "agents:sample", "--apply"],
+    undefined,
+    {
+      AI_CONFIG_SYNC_HOST: "codex",
+    }
+  );
+  const claudeFile = readFileSync(join(fixture.project, ".claude/agents/sample.md"), "utf8");
+
+  assert.match(claudeFile, /^model: sonnet$/m);
+});
+
+test("agents sync apply rewrites a Codex agent name Claude would reject for its colon", () => {
+  const fixture = createFixture();
+  mkdirSync(join(fixture.project, ".claude/agents"), { recursive: true });
+  writeCodexAgent(join(fixture.project, ".codex/agents/namespaced.toml"), {
+    name: "plugin:sample",
+    description: "Example agent",
+    model: "gpt-5.6-terra",
+    developer_instructions: "Real codex content",
+  });
+
+  const output = runCli(
+    fixture,
+    ["sync", "--scope", "project", "--include", "agents", "--apply"],
+    undefined,
+    { AI_CONFIG_SYNC_HOST: "codex" }
+  );
+
+  assert.match(output, /copied agent plugin-sample/);
+  const claudeFile = readFileSync(join(fixture.project, ".claude/agents/plugin-sample.md"), "utf8");
+  assert.doesNotMatch(claudeFile, /^name:.*:/m);
 });
 
 test("agents sync apply preserves Codex metadata-only fields when overwriting", () => {
@@ -3283,11 +3370,11 @@ test("sync apply transforms TeamCreate call with flat named-args + members array
   assert.match(codexBody, /Use `multi_agent_v2\.spawn_agent` to launch the "review-team" team/);
   assert.match(
     codexBody,
-    /### Member: code \(agent_type: "browser-audit\/code-security-auditor", model: "gpt-5\.6"\)/
+    /### Member: code \(agent_type: "browser-audit\/code-security-auditor", model: "gpt-5\.6-terra"\)/
   );
   assert.match(
     codexBody,
-    /### Member: browser \(agent_type: "browser-audit\/browser-runtime-auditor", model: "gpt-5\.6"\)/
+    /### Member: browser \(agent_type: "browser-audit\/browser-runtime-auditor", model: "gpt-5\.6-terra"\)/
   );
   assert.doesNotMatch(codexBody, /TeamCreate\(/);
   assert.doesNotMatch(codexBody, /ai-config-sync:manual-review/);
@@ -3326,7 +3413,12 @@ test("sync apply round-trips Codex team-call marker back into Claude TeamCreate(
   const markerFields = {
     team_name: "review-team",
     members: [
-      { name: "code", agent_type: "browser-audit/code", model: "gpt-5.6", prompt: "Audit code." },
+      {
+        name: "code",
+        agent_type: "browser-audit/code",
+        model: "gpt-5.6-terra",
+        prompt: "Audit code.",
+      },
     ],
   };
   const markerPayload = JSON.stringify({ call: "TeamCreate", fields: markerFields });
@@ -3338,7 +3430,7 @@ test("sync apply round-trips Codex team-call marker back into Claude TeamCreate(
       `<!-- ai-config-sync:team-call ${markerPayload} -->`,
       'Use `multi_agent_v2.spawn_agent` to launch the "review-team" team. Each member runs in parallel.',
       "",
-      '### Member: code (agent_type: "browser-audit/code", model: "gpt-5.6")',
+      '### Member: code (agent_type: "browser-audit/code", model: "gpt-5.6-terra")',
       "Audit code.",
       "",
       "",
@@ -6041,7 +6133,7 @@ test("sync applies layered partial merge to agents-map: model tier id override e
   runCli(fixture, ["sync", "--scope", "project", "--include", "instructions", "--apply"]);
   const agents = readFileSync(join(fixture.project, "AGENTS.md"), "utf8");
 
-  assert.equal(agents, "Use gpt-5.5 today and gpt-5.4 for chat.\n");
+  assert.equal(agents, "Use gpt-5.5 today and gpt-5.6-luna for chat.\n");
 });
 
 // ---------------------------------------------------------------------------
@@ -6539,7 +6631,7 @@ test("status surfaces vocab-mismatch when claude agent body uses spawn_agent", (
   writeCodexAgent(join(fixture.home, ".codex/agents/sample.toml"), {
     name: "sample",
     description: "demo agent",
-    model: "gpt-5.6",
+    model: "gpt-5.6-terra",
     developer_instructions: "spawn_agent를 호출한다.\n",
   });
 

--- a/tests/detect-enum-drift.test.mjs
+++ b/tests/detect-enum-drift.test.mjs
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  resolveEnumMembers,
+  hookEventNames,
+  findCodexEnumDrift,
+  findClaudeHookDrift,
+  renderSection,
+} from "../scripts/detect-enum-drift.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const codexSchemaPath = join(here, "..", "snapshots", "codex", "config-schema.json");
+const claudeSchemaPath = join(here, "..", "snapshots", "claude", "settings-schema.json");
+
+function refSchema(members) {
+  return {
+    properties: { sandbox_mode: { allOf: [{ $ref: "#/definitions/SandboxMode" }] } },
+    definitions: { SandboxMode: { enum: members, type: "string" } },
+  };
+}
+
+// The shipped schema states these keys as $ref indirections, which is what the previous jq-based
+// check could not follow — it read [] for every watched key and never fired.
+test("resolveEnumMembers follows the $ref the real Codex schema uses", () => {
+  const schema = JSON.parse(readFileSync(codexSchemaPath, "utf8"));
+  assert.deepEqual(resolveEnumMembers(schema, "sandbox_mode"), [
+    "danger-full-access",
+    "read-only",
+    "workspace-write",
+  ]);
+  assert.ok(resolveEnumMembers(schema, "approval_policy").length > 0);
+  assert.ok(resolveEnumMembers(schema, "web_search").includes("live"));
+});
+
+test("resolveEnumMembers collects members spelled as oneOf branches", () => {
+  const schema = {
+    properties: { web_search: { allOf: [{ $ref: "#/definitions/WebSearchMode" }] } },
+    definitions: {
+      WebSearchMode: { oneOf: [{ enum: ["live"] }, { enum: ["cached"] }] },
+    },
+  };
+  assert.deepEqual(resolveEnumMembers(schema, "web_search"), ["cached", "live"]);
+});
+
+test("resolveEnumMembers returns nothing for an absent key", () => {
+  assert.deepEqual(resolveEnumMembers(refSchema(["read-only"]), "approval_policy"), []);
+});
+
+test("hookEventNames reads the real Claude schema", () => {
+  const schema = JSON.parse(readFileSync(claudeSchemaPath, "utf8"));
+  const events = hookEventNames(schema);
+  for (const event of ["PreToolUse", "PostToolUse", "SessionStart", "UserPromptSubmit"]) {
+    assert.ok(events.includes(event), `missing ${event}`);
+  }
+});
+
+test("codex enum drift reports added and removed members", () => {
+  const findings = findCodexEnumDrift(
+    refSchema(["danger-full-access", "read-only", "workspace-write"]),
+    refSchema(["read-only", "workspace-jail"]),
+    { sandbox_mode: "workspace-write" }
+  );
+  assert.deepEqual(findings, [
+    {
+      key: "sandbox_mode",
+      added: ["danger-full-access", "workspace-write"],
+      removed: ["workspace-jail"],
+    },
+  ]);
+});
+
+test("codex enum drift flags a hardcoded value the schema dropped", () => {
+  const findings = findCodexEnumDrift(refSchema(["read-only"]), refSchema(["read-only"]), {
+    sandbox_mode: "workspace-write",
+  });
+  assert.deepEqual(findings, [{ key: "sandbox_mode", stale: "workspace-write" }]);
+});
+
+test("codex enum drift flags a watched key that vanished entirely", () => {
+  const findings = findCodexEnumDrift({ properties: {} }, refSchema(["read-only"]), {
+    sandbox_mode: "workspace-write",
+  });
+  assert.deepEqual(findings, [{ key: "sandbox_mode", missingKey: true }]);
+});
+
+test("codex enum drift stays silent when the watched enum is unchanged", () => {
+  const schema = refSchema(["read-only", "workspace-write"]);
+  assert.deepEqual(findCodexEnumDrift(schema, schema, { sandbox_mode: "workspace-write" }), []);
+});
+
+test("claude hook drift flags a hardcoded event the schema dropped", () => {
+  const current = { properties: { hooks: { properties: { PreToolUse: {} } } } };
+  const previous = { properties: { hooks: { properties: { PreToolUse: {}, SessionStart: {} } } } };
+  const findings = findClaudeHookDrift(current, previous, ["PreToolUse", "SessionStart"]);
+  assert.deepEqual(findings, [
+    { key: "hooks", added: [], removed: ["SessionStart"] },
+    { key: "hooks", stale: "SessionStart" },
+  ]);
+});
+
+test("the shipped schemas keep every value the runtime hardcodes", () => {
+  const codex = JSON.parse(readFileSync(codexSchemaPath, "utf8"));
+  const claude = JSON.parse(readFileSync(claudeSchemaPath, "utf8"));
+  assert.deepEqual(findCodexEnumDrift(codex, codex), []);
+  assert.deepEqual(findClaudeHookDrift(claude, claude), []);
+});
+
+test("renderSection is empty when nothing drifted", () => {
+  assert.equal(renderSection([], []), "");
+});
+
+test("renderSection labels stale hardcoded values per host", () => {
+  const section = renderSection(
+    [{ key: "hooks", stale: "PreToolUse" }],
+    [{ key: "sandbox_mode", stale: "workspace-write" }]
+  );
+  assert.match(section, /## Compat scan — enum drift on watched keys/);
+  assert.match(section, /### Claude\n- \*\*STALE HARDCODED\*\* hook event `PreToolUse`/);
+  assert.match(section, /### Codex\n- \*\*STALE HARDCODED\*\* `sandbox_mode = "workspace-write"`/);
+});

--- a/tests/detect-model-drift.test.mjs
+++ b/tests/detect-model-drift.test.mjs
@@ -46,8 +46,20 @@ test("stale tier surfaces when Opus bumps past the recorded version", () => {
   assert.match(drift[0].note, /갱신/);
 });
 
-test("Fable is intentionally excluded from detection", () => {
-  assert.deepEqual(findModelDrift("Meet Claude Fable 5, a creative-writing model.", TIERS), []);
+// Fable used to be stopworded as a product name. Fable 5 shipped as a real model tier, and the
+// stopword meant every changelog mention of it was dropped instead of reported.
+test("Fable surfaces as drift while it is missing from the tiers", () => {
+  const drift = findModelDrift("Meet Claude Fable 5, a Mythos-class model.", TIERS);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].raw, "Claude Fable 5");
+});
+
+test("Fable stays silent once a tier claims it", () => {
+  const tiers = [
+    { id: "mythos-class-model", claude: { alias: "fable", terms: ["Claude Fable 5", "Fable 5"] } },
+    ...TIERS,
+  ];
+  assert.deepEqual(findModelDrift("Meet Claude Fable 5, a Mythos-class model.", tiers), []);
 });
 
 test("hyphenated model ids are extracted", () => {


### PR DESCRIPTION
Closes the three items the [#33 compat review](https://github.com/slash9494/ai-config-sync-manager/pull/33#issuecomment-5078291039) left for a human. Researching the model one turned up a fourth problem, described below.

Each of the three had the same shape: the tool reported success while producing something the target host cannot use, or reported "all clear" without having looked.

## 1. Agent names could carry a colon

Claude has rejected `:` in agent names since CLI 2.1.218 — it is reserved for plugin namespacing. `canonicalAgentName` stripped only `/`, and `mapAgentToClaude` did not call it at all, copying the raw Codex name straight into the frontmatter.

A Codex agent named `plugin:sample` therefore produced a file Claude refuses to load, saved under a file name that *had* been sanitized and so no longer matched its own `name:` field. The test caught that second half — the first attempt fixed only the file name and the frontmatter still read `plugin:sample`.

## 2. `fable` had no tier, and the tiers named retired models

`model: fable` was copied to Codex verbatim, because `modelAliasMap` leaves an unknown token untouched and Codex has no such model.

Checking that turned up more: **`gpt-5.4` retired on 2026-07-23** and `gpt-5.4-mini` is a generation behind, but the balanced and small tiers still named them. The Claude side still said "Opus 4.8" after Opus 5 shipped.

The two lineups line up rank for rank — Fable 5 sits above Opus in the Mythos class the way Sol leads GPT-5.6, with Terra and Luna following Opus and Sonnet down:

| tier | Claude | Codex |
| --- | --- | --- |
| `mythos-class-model` (new) | `fable` | `gpt-5.6-sol` |
| `latest-frontier-model` | `opus` | `gpt-5.6-terra` |
| `balanced-model` | `sonnet` | `gpt-5.6-luna` |
| `small-fast-model` | `haiku` | `gpt-5.4-mini` |

Haiku keeps `gpt-5.4-mini` because GPT-5.6 stops at three tiers.

Sources: [Claude models overview](https://platform.claude.com/docs/en/about-claude/models/overview), [Codex models](https://developers.openai.com/codex/models), [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol).

`modelAliasMap` now also keys off each tier's `terms`, so retired ids (`gpt-5.4`, `gpt-5.5`) and the vendor-tagged coding variants (`gpt-5.3-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`) resolve to a tier instead of passing through. Reusing `terms` avoids a second list to keep in sync. Where two tiers could claim a token the earlier — stronger — one wins, which is why the lookup skips a key it has already filled; a test pins that.

**Why nobody noticed:** `scripts/detect-model-drift.mjs` listed `fable` among the Claude product words, so every changelog mention of Fable 5 was dropped before it could be reported. Removed, with the "intentionally excluded" test inverted.

## 3. The enum-drift guard has never been able to fire

It exists to catch upstream dropping a value the runtime hardcodes — above all `sandbox_mode = "workspace-write"`, which `rules/agents-map.json` maps Claude tool sets onto.

The extractor read `.properties[key].oneOf[].enum[]` and `.properties[key].enum[]`, but the schema states every watched key as an indirection:

```json
"sandbox_mode": { "allOf": [{ "$ref": "#/definitions/SandboxMode" }] }
```

`jq` does not follow `$ref`, so the member list came back empty every run. That emptied the added/removed comparison, and the `STALE HARDCODED` branch sat behind `[ -n "$curr" ]`, so it was skipped too. A green report meant nothing had been read, not that nothing had changed.

Moving the check into `scripts/detect-enum-drift.mjs` is what makes the fix stick: shell buried in a `run:` block cannot be tested, which is exactly why this went unnoticed. It follows `allOf`/`oneOf`/`anyOf` and `$ref`, and a watched key vanishing outright is now reported too — the old code was silent about that as well. Same pattern as the existing `detect-model-drift.mjs`; the workflow loses 65 lines of shell.

## Verification

- `npm test` — **377/377**, up from 360. New: 4 agent conversion tests, 12 enum-drift tests, 1 net model-drift test.
- `tests/detect-enum-drift.test.mjs` asserts against the shipped snapshots: the real schema yields all three sandbox modes, and a standing test fails if any hardcoded value ever leaves its enum.
- Ran the guard against the real schema with `workspace-write` removed; it reports both the removal and `STALE HARDCODED`.
- `prettier --check .` clean. `eslint .` reports 3 warnings, all pre-existing (confirmed by stashing).
- Fixture churn in `cli-fixtures.test.mjs` is the tier remap: pairs that read `opus4.8(latest)` / `gpt-5.6` now read `opus(latest)` / `gpt-5.6-terra`.

## Notes

- Touches `.github/workflows/upstream-compat.yml` like #38 does, but a different region (#38 changes the cron at the top; this replaces the enum block near the bottom).
- No CHANGELOG entry — entries here land with the release commit.
- The PR #33 comment said the tiers needed no version bump. That was wrong, and this corrects it: it leaned on the `effortLevel` description in the Claude settings schema, which still lists Opus 4.8 because that prose has not been updated, rather than on the published model lineup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Mythos model tier and updated model aliases and accepted names.
  * Improved model conversion across Claude and Codex, including vendor-tagged and shared model names.
  * Improved agent-name compatibility when synchronizing between platforms.

* **Documentation**
  * Updated customization and reference documentation with current model mappings and tier-resolution behavior.

* **Bug Fixes**
  * Improved detection of schema compatibility changes and model-name drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->