### PR TITLE
fix(compat): resolve $ref in the enum-drift guard so it can fire

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -354,71 +354,9 @@ jobs:
               fi
             } >> .upstream-compat/body.md
           fi
-          # Enum drift: enum-bearing keys the runtime hardcodes. Members added/removed AND hardcoded values stale.
-          extract_enum_members() {
-            local file="$1" key="$2"
-            [ -f "$file" ] || return 0
-            jq -r --arg k "$key" '[.properties[$k].oneOf[]?.enum[]?, .properties[$k].enum[]?] | unique | .[]' "$file" 2>/dev/null | sort -u
-          }
-          extract_enum_members_head() {
-            local path="$1" key="$2"
-            git show "HEAD:$path" 2>/dev/null | jq -r --arg k "$key" '[.properties[$k].oneOf[]?.enum[]?, .properties[$k].enum[]?] | unique | .[]' 2>/dev/null | sort -u || true
-          }
-          # Codex enum-bearing keys + the value the runtime hardcodes.
-          codex_enum_watch="snapshots/codex/config-schema.json:sandbox_mode:workspace-write
-          snapshots/codex/config-schema.json:approval_policy:on-request
-          snapshots/codex/config-schema.json:web_search:live"
-          codex_enum_drift=""
-          while IFS=: read -r file key val; do
-            file=$(echo "$file" | sed 's/^ *//')
-            [ -z "${file:-}" ] && continue
-            curr=$(extract_enum_members "$file" "$key")
-            prev=$(extract_enum_members_head "$file" "$key")
-            added=$(comm -23 <(printf '%s\n' "$curr") <(printf '%s\n' "$prev") | sed '/^$/d' | tr '\n' ' ' | sed 's/ *$//' || true)
-            removed=$(comm -13 <(printf '%s\n' "$curr") <(printf '%s\n' "$prev") | sed '/^$/d' | tr '\n' ' ' | sed 's/ *$//' || true)
-            if [ -n "$added" ] || [ -n "$removed" ]; then
-              codex_enum_drift="${codex_enum_drift}- \`${key}\` enum changed"$'\n'
-              [ -n "$added" ] && codex_enum_drift="${codex_enum_drift}  - added: ${added}"$'\n'
-              [ -n "$removed" ] && codex_enum_drift="${codex_enum_drift}  - removed: ${removed}"$'\n'
-            fi
-            if [ -n "$curr" ] && ! printf '%s\n' "$curr" | grep -qx "$val"; then
-              codex_enum_drift="${codex_enum_drift}- **STALE HARDCODED** \`${key} = \"${val}\"\` no longer in schema enum (runtime will write an invalid value)"$'\n'
-            fi
-          done <<< "$codex_enum_watch"
-          # Claude hardcoded hook event names: properties.hooks.properties.<EventName>
-          claude_hook_events_curr=$(jq -r '.properties.hooks.properties // {} | keys[]' snapshots/claude/settings-schema.json 2>/dev/null | sort -u)
-          claude_hook_events_prev=$(git show HEAD:snapshots/claude/settings-schema.json 2>/dev/null | jq -r '.properties.hooks.properties // {} | keys[]' 2>/dev/null | sort -u || true)
-          claude_hook_added=$(comm -23 <(printf '%s\n' "$claude_hook_events_curr") <(printf '%s\n' "$claude_hook_events_prev") | sed '/^$/d' | tr '\n' ' ' | sed 's/ *$//' || true)
-          claude_hook_removed=$(comm -13 <(printf '%s\n' "$claude_hook_events_curr") <(printf '%s\n' "$claude_hook_events_prev") | sed '/^$/d' | tr '\n' ' ' | sed 's/ *$//' || true)
-          claude_enum_drift=""
-          if [ -n "$claude_hook_added" ] || [ -n "$claude_hook_removed" ]; then
-            claude_enum_drift="${claude_enum_drift}- \`hooks\` event names changed"$'\n'
-            [ -n "$claude_hook_added" ] && claude_enum_drift="${claude_enum_drift}  - added: ${claude_hook_added}"$'\n'
-            [ -n "$claude_hook_removed" ] && claude_enum_drift="${claude_enum_drift}  - removed: ${claude_hook_removed}"$'\n'
-          fi
-          for ev in PreToolUse PostToolUse SessionStart UserPromptSubmit; do
-            if [ -n "$claude_hook_events_curr" ] && ! printf '%s\n' "$claude_hook_events_curr" | grep -qx "$ev"; then
-              claude_enum_drift="${claude_enum_drift}- **STALE HARDCODED** hook event \`${ev}\` no longer in \`hooks.properties\` (runtime writes a hook the host will not fire)"$'\n'
-            fi
-          done
-          if [ -n "${claude_enum_drift:-}" ] || [ -n "${codex_enum_drift:-}" ]; then
-            {
-              echo
-              echo "## Compat scan — enum drift on watched keys"
-              echo
-              echo "Enum members on keys the runtime hardcodes. STALE HARDCODED means \`bin/ai-config-sync.mjs\` will emit a value the new schema rejects — runtime fix required, not just a checklist."
-              if [ -n "${claude_enum_drift:-}" ]; then
-                echo
-                echo "### Claude"
-                printf '%s\n' "$claude_enum_drift"
-              fi
-              if [ -n "${codex_enum_drift:-}" ]; then
-                echo
-                echo "### Codex"
-                printf '%s\n' "$codex_enum_drift"
-              fi
-            } >> .upstream-compat/body.md
-          fi
+          # Enum drift on keys the runtime hardcodes. The schema states them as $ref indirections,
+          # so resolving them needs a real walk, not a flat read of the property's own .enum.
+          node scripts/detect-enum-drift.mjs >> .upstream-compat/body.md || true
           # Model tiers live in agents-map.json, never in the settings/config schema — detect from changelog/releases prose.
           node scripts/detect-model-drift.mjs >> .upstream-compat/body.md || true
           # Raw diff goes LAST, capped to the remaining GitHub PR-body budget (hard limit 65536).

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "refresh:cache": "node scripts/refresh-cache.mjs",
     "snapshot:upstream": "node scripts/snapshot-upstream.mjs",
     "snapshot:model-drift": "node scripts/detect-model-drift.mjs",
+    "snapshot:enum-drift": "node scripts/detect-enum-drift.mjs",
     "test": "node --test tests/*.test.mjs tests/integration/codex-to-claude/*.test.mjs",
     "test:manual:reset": "tests/integration/manual-codex-to-claude/scripts/reset.sh",
     "test:manual:run": "tests/integration/manual-codex-to-claude/scripts/run-cases.sh",

--- a/scripts/detect-enum-drift.mjs
+++ b/scripts/detect-enum-drift.mjs
@@ -45,16 +45,50 @@ function walk(schema, node, visit, hops = 0, seen = new Set()) {
   }
   const ref = node.$ref;
   if (typeof ref !== "string" || seen.has(ref)) return;
-  seen.add(ref);
-  walk(schema, definitionFor(schema, ref), visit, hops + 1, seen);
+  walk(schema, definitionFor(schema, ref), visit, hops + 1, new Set(seen).add(ref));
+}
+
+function intersect(left, right) {
+  return new Set([...left].filter((member) => right.has(member)));
+}
+
+// Returns null when the node says nothing about allowed values, which is what separates "this key
+// is not an enum" from "it is an enum with no members left". `allOf` narrows and `oneOf`/`anyOf`
+// widen, so treating them alike would read a narrowed key as unchanged — the exact false negative
+// this guard exists to end.
+function memberConstraint(schema, node, hops = 0, seen = new Set()) {
+  if (!node || typeof node !== "object" || hops > MAX_REF_HOPS) return null;
+  const constraints = [];
+  if (Array.isArray(node.enum)) constraints.push(new Set(node.enum));
+  for (const key of ["oneOf", "anyOf"]) {
+    const branches = (Array.isArray(node[key]) ? node[key] : [])
+      .map((child) => memberConstraint(schema, child, hops, seen))
+      .filter(Boolean);
+    if (branches.length > 0) {
+      constraints.push(new Set(branches.flatMap((branch) => [...branch])));
+    }
+  }
+  for (const child of Array.isArray(node.allOf) ? node.allOf : []) {
+    const branch = memberConstraint(schema, child, hops, seen);
+    if (branch) constraints.push(branch);
+  }
+  const ref = node.$ref;
+  if (typeof ref === "string" && !seen.has(ref)) {
+    const target = memberConstraint(
+      schema,
+      definitionFor(schema, ref),
+      hops + 1,
+      new Set(seen).add(ref)
+    );
+    if (target) constraints.push(target);
+  }
+  if (constraints.length === 0) return null;
+  return constraints.reduce(intersect);
 }
 
 export function resolveEnumMembers(schema, key) {
-  const members = new Set();
-  walk(schema, schema?.properties?.[key], (node) => {
-    for (const value of Array.isArray(node.enum) ? node.enum : []) members.add(value);
-  });
-  return [...members].sort();
+  const constraint = memberConstraint(schema, schema?.properties?.[key]);
+  return constraint ? [...constraint].sort() : [];
 }
 
 export function hookEventNames(schema) {
@@ -84,12 +118,16 @@ export function findCodexEnumDrift(current, previous, watch = CODEX_WATCH) {
       continue;
     }
     const members = resolveEnumMembers(current, key);
+    const before = previous ? resolveEnumMembers(previous, key) : [];
     if (previous) {
-      const { added, removed } = memberDiff(members, resolveEnumMembers(previous, key));
+      const { added, removed } = memberDiff(members, before);
       if (added.length > 0 || removed.length > 0) findings.push({ key, added, removed });
     }
-    if (members.length > 0 && !members.includes(hardcoded))
-      findings.push({ key, stale: hardcoded });
+    // A key that stops being an enum is the loudest signal available, not the quietest: the runtime
+    // keeps writing its string into whatever the field became. Gating on the current member list
+    // alone downgrades that to a plain "enum changed" bullet.
+    const constrained = members.length > 0 || before.length > 0;
+    if (constrained && !members.includes(hardcoded)) findings.push({ key, stale: hardcoded });
   }
   return findings;
 }

--- a/scripts/detect-enum-drift.mjs
+++ b/scripts/detect-enum-drift.mjs
@@ -1,0 +1,199 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const CODEX_SCHEMA = "snapshots/codex/config-schema.json";
+const CLAUDE_SCHEMA = "snapshots/claude/settings-schema.json";
+
+// Watched key -> the value bin/ai-config-sync.mjs writes for it.
+const CODEX_WATCH = {
+  sandbox_mode: "workspace-write",
+  approval_policy: "on-request",
+  web_search: "live",
+};
+const CLAUDE_HOOK_EVENTS = ["PreToolUse", "PostToolUse", "SessionStart", "UserPromptSubmit"];
+
+// The two hosts already disagree: the Codex schema is draft-07 with `definitions`, the Claude one
+// uses `$defs`. Supporting only the spelling a host happens to use today would turn a schema
+// generator bump into "every member was removed" plus a silently skipped stale check.
+const REF_PREFIXES = ["#/definitions/", "#/$defs/"];
+const MAX_REF_HOPS = 16;
+const COMPOSITION_KEYS = ["oneOf", "anyOf", "allOf"];
+
+// git show streams a whole schema; the Claude one is already ~200 KB and grows every release, and
+// Node's 1 MiB default would turn that growth into a silent scan failure.
+const GIT_SHOW_MAX_BUFFER = 64 * 1024 * 1024;
+
+function definitionFor(schema, ref) {
+  for (const prefix of REF_PREFIXES) {
+    if (!ref.startsWith(prefix)) continue;
+    const name = ref.slice(prefix.length);
+    return schema?.definitions?.[name] ?? schema?.$defs?.[name];
+  }
+  return undefined;
+}
+
+// Hops count $ref indirections only. Counting composition depth too made a single `allOf` + `$ref`
+// wrapper cost two of the budget, so a schema nested a few layers deeper resolved to nothing.
+function walk(schema, node, visit, hops = 0, seen = new Set()) {
+  if (!node || typeof node !== "object" || hops > MAX_REF_HOPS) return;
+  visit(node);
+  for (const key of COMPOSITION_KEYS) {
+    for (const child of Array.isArray(node[key]) ? node[key] : []) {
+      walk(schema, child, visit, hops, seen);
+    }
+  }
+  const ref = node.$ref;
+  if (typeof ref !== "string" || seen.has(ref)) return;
+  seen.add(ref);
+  walk(schema, definitionFor(schema, ref), visit, hops + 1, seen);
+}
+
+export function resolveEnumMembers(schema, key) {
+  const members = new Set();
+  walk(schema, schema?.properties?.[key], (node) => {
+    for (const value of Array.isArray(node.enum) ? node.enum : []) members.add(value);
+  });
+  return [...members].sort();
+}
+
+export function hookEventNames(schema) {
+  const events = new Set();
+  walk(schema, schema?.properties?.hooks, (node) => {
+    if (!node.properties || typeof node.properties !== "object") return;
+    for (const name of Object.keys(node.properties)) events.add(name);
+  });
+  return [...events].sort();
+}
+
+function memberDiff(current, previous) {
+  return {
+    added: current.filter((member) => !previous.includes(member)),
+    removed: previous.filter((member) => !current.includes(member)),
+  };
+}
+
+// `previous` is optional on purpose: the stale-hardcoded check reads only the current schema, and
+// tying it to a readable HEAD copy would silence it exactly when a snapshot is newly added.
+export function findCodexEnumDrift(current, previous, watch = CODEX_WATCH) {
+  const findings = [];
+  const readable = Object.keys(current?.properties ?? {}).length > 0;
+  for (const [key, hardcoded] of Object.entries(watch)) {
+    if (readable && !current.properties[key]) {
+      findings.push({ key, missingKey: true });
+      continue;
+    }
+    const members = resolveEnumMembers(current, key);
+    if (previous) {
+      const { added, removed } = memberDiff(members, resolveEnumMembers(previous, key));
+      if (added.length > 0 || removed.length > 0) findings.push({ key, added, removed });
+    }
+    if (members.length > 0 && !members.includes(hardcoded))
+      findings.push({ key, stale: hardcoded });
+  }
+  return findings;
+}
+
+export function findClaudeHookDrift(current, previous, hardcoded = CLAUDE_HOOK_EVENTS) {
+  const findings = [];
+  const events = hookEventNames(current);
+  if (previous) {
+    const { added, removed } = memberDiff(events, hookEventNames(previous));
+    if (added.length > 0 || removed.length > 0) findings.push({ key: "hooks", added, removed });
+  }
+  if (events.length === 0) return findings;
+  for (const event of hardcoded) {
+    if (!events.includes(event)) findings.push({ key: "hooks", stale: event });
+  }
+  return findings;
+}
+
+function renderFinding(finding, staleLabel) {
+  if (finding.unreadable) {
+    return `- **SCAN SKIPPED** \`${finding.unreadable}\` could not be read, so nothing was checked`;
+  }
+  if (finding.missingKey) {
+    return `- **KEY GONE** \`${finding.key}\` is no longer in the schema at all`;
+  }
+  if (finding.stale) return `- **STALE HARDCODED** ${staleLabel(finding)}`;
+  const lines = [`- \`${finding.key}\` enum changed`];
+  if (finding.added.length > 0) lines.push(`  - added: ${finding.added.join(" ")}`);
+  if (finding.removed.length > 0) lines.push(`  - removed: ${finding.removed.join(" ")}`);
+  return lines.join("\n");
+}
+
+export function renderSection(claudeFindings, codexFindings) {
+  if (claudeFindings.length === 0 && codexFindings.length === 0) return "";
+  const lines = [
+    "",
+    "## Compat scan — enum drift on watched keys",
+    "",
+    "Enum members on keys the runtime hardcodes. STALE HARDCODED means `bin/ai-config-sync.mjs` will emit a value the new schema rejects — runtime fix required, not just a checklist.",
+  ];
+  const hosts = [
+    [
+      "Claude",
+      claudeFindings,
+      (f) =>
+        `hook event \`${f.stale}\` no longer in \`hooks.properties\` (runtime writes a hook the host will not fire)`,
+    ],
+    [
+      "Codex",
+      codexFindings,
+      (f) =>
+        `\`${f.key} = "${f.stale}"\` no longer in schema enum (runtime will write an invalid value)`,
+    ],
+  ];
+  for (const [title, findings, staleLabel] of hosts) {
+    if (findings.length === 0) continue;
+    lines.push("", `### ${title}`);
+    for (const finding of findings) lines.push(renderFinding(finding, staleLabel));
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function readSchema(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    // An empty object would read as "every watched key was removed upstream" and invent a KEY GONE
+    // report out of a local read failure.
+    process.stderr.write(`detect-enum-drift: cannot read ${path}: ${err.message}\n`);
+    return null;
+  }
+}
+
+function readSchemaAtHead(path) {
+  try {
+    return JSON.parse(
+      execFileSync("git", ["show", `HEAD:${path}`], {
+        encoding: "utf8",
+        maxBuffer: GIT_SHOW_MAX_BUFFER,
+      })
+    );
+  } catch (err) {
+    process.stderr.write(`detect-enum-drift: cannot read HEAD:${path}: ${err.message}\n`);
+    return null;
+  }
+}
+
+// An unreadable current schema is reported rather than skipped — the section being absent is how a
+// reviewer concludes the scan ran and found nothing.
+function scan(path, find) {
+  const current = readSchema(path);
+  if (!current) return [{ unreadable: path }];
+  return find(current, readSchemaAtHead(path));
+}
+
+function main() {
+  const section = renderSection(
+    scan(CLAUDE_SCHEMA, findClaudeHookDrift),
+    scan(CODEX_SCHEMA, findCodexEnumDrift)
+  );
+  if (section) process.stdout.write(section);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/detect-enum-drift.mjs
+++ b/scripts/detect-enum-drift.mjs
@@ -110,10 +110,12 @@ function memberDiff(current, previous) {
 // `previous` is optional on purpose: the stale-hardcoded check reads only the current schema, and
 // tying it to a readable HEAD copy would silence it exactly when a snapshot is newly added.
 export function findCodexEnumDrift(current, previous, watch = CODEX_WATCH) {
+  // A snapshot with no properties at all is not a schema — an upstream 200 carrying an error body
+  // parses fine and would otherwise diff as "every member of every watched key was removed".
+  if (Object.keys(current?.properties ?? {}).length === 0) return [{ notASchema: true }];
   const findings = [];
-  const readable = Object.keys(current?.properties ?? {}).length > 0;
   for (const [key, hardcoded] of Object.entries(watch)) {
-    if (readable && !current.properties[key]) {
+    if (!current.properties[key]) {
       findings.push({ key, missingKey: true });
       continue;
     }
@@ -133,6 +135,7 @@ export function findCodexEnumDrift(current, previous, watch = CODEX_WATCH) {
 }
 
 export function findClaudeHookDrift(current, previous, hardcoded = CLAUDE_HOOK_EVENTS) {
+  if (Object.keys(current?.properties ?? {}).length === 0) return [{ notASchema: true }];
   const findings = [];
   const events = hookEventNames(current);
   if (previous) {
@@ -149,6 +152,9 @@ export function findClaudeHookDrift(current, previous, hardcoded = CLAUDE_HOOK_E
 function renderFinding(finding, staleLabel) {
   if (finding.unreadable) {
     return `- **SCAN SKIPPED** \`${finding.unreadable}\` could not be read, so nothing was checked`;
+  }
+  if (finding.notASchema) {
+    return "- **SCAN SKIPPED** the snapshot parsed but declares no properties, so it is not a schema";
   }
   if (finding.missingKey) {
     return `- **KEY GONE** \`${finding.key}\` is no longer in the schema at all`;

--- a/tests/detect-enum-drift.test.mjs
+++ b/tests/detect-enum-drift.test.mjs
@@ -188,9 +188,25 @@ test("codex enum drift flags a watched key that vanished entirely", () => {
   assert.deepEqual(findings, [{ key: "sandbox_mode", missingKey: true }]);
 });
 
-// An empty properties map means the schema was not understood, not that upstream deleted the keys.
-test("codex enum drift does not claim keys vanished when no property is readable", () => {
-  assert.deepEqual(findCodexEnumDrift({}, null, { sandbox_mode: "workspace-write" }), []);
+// snapshot-upstream writes any body that parses as JSON, so an upstream 200 carrying an error
+// payload lands here looking valid. Diffing it would claim every watched key lost every member.
+test("codex enum drift reports a non-schema snapshot instead of diffing it", () => {
+  const findings = findCodexEnumDrift({ message: "Moved" }, refSchema(["read-only"]), {
+    sandbox_mode: "workspace-write",
+  });
+  assert.deepEqual(findings, [{ notASchema: true }]);
+});
+
+test("claude hook drift reports a non-schema snapshot instead of diffing it", () => {
+  const previous = { properties: { hooks: { properties: { PreToolUse: {} } } } };
+  assert.deepEqual(findClaudeHookDrift({ message: "Moved" }, previous), [{ notASchema: true }]);
+});
+
+test("renderSection names a snapshot that parsed but is not a schema", () => {
+  assert.match(
+    renderSection([], [{ notASchema: true }]),
+    /\*\*SCAN SKIPPED\*\* the snapshot parsed/
+  );
 });
 
 test("codex enum drift stays silent when the watched enum is unchanged", () => {

--- a/tests/detect-enum-drift.test.mjs
+++ b/tests/detect-enum-drift.test.mjs
@@ -1,0 +1,190 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  resolveEnumMembers,
+  hookEventNames,
+  findCodexEnumDrift,
+  findClaudeHookDrift,
+  renderSection,
+} from "../scripts/detect-enum-drift.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const codexSchemaPath = join(here, "..", "snapshots", "codex", "config-schema.json");
+const claudeSchemaPath = join(here, "..", "snapshots", "claude", "settings-schema.json");
+
+function refSchema(members, { defsKey = "definitions", refPrefix = "#/definitions/" } = {}) {
+  return {
+    properties: { sandbox_mode: { allOf: [{ $ref: `${refPrefix}SandboxMode` }] } },
+    [defsKey]: { SandboxMode: { enum: members, type: "string" } },
+  };
+}
+
+// The shipped Codex schema states these keys as $ref indirections, which is what the previous
+// jq-based check could not follow — it read [] for every watched key and never fired.
+test("resolveEnumMembers follows the $ref the real Codex schema uses", () => {
+  const schema = JSON.parse(readFileSync(codexSchemaPath, "utf8"));
+  assert.deepEqual(resolveEnumMembers(schema, "sandbox_mode"), [
+    "danger-full-access",
+    "read-only",
+    "workspace-write",
+  ]);
+  assert.ok(resolveEnumMembers(schema, "approval_policy").length > 0);
+  assert.ok(resolveEnumMembers(schema, "web_search").includes("live"));
+});
+
+// Codex ships `definitions`, Claude ships `$defs`; a generator bump can move either host.
+test("resolveEnumMembers reads both the definitions and $defs spellings", () => {
+  const members = ["read-only", "workspace-write"];
+  assert.deepEqual(resolveEnumMembers(refSchema(members), "sandbox_mode"), members);
+  assert.deepEqual(
+    resolveEnumMembers(
+      refSchema(members, { defsKey: "$defs", refPrefix: "#/$defs/" }),
+      "sandbox_mode"
+    ),
+    members
+  );
+});
+
+test("resolveEnumMembers collects members spelled as oneOf branches", () => {
+  const schema = {
+    properties: { web_search: { allOf: [{ $ref: "#/definitions/WebSearchMode" }] } },
+    definitions: { WebSearchMode: { oneOf: [{ enum: ["live"] }, { enum: ["cached"] }] } },
+  };
+  assert.deepEqual(resolveEnumMembers(schema, "web_search"), ["cached", "live"]);
+});
+
+test("resolveEnumMembers survives a chain of wrappers and a $ref cycle", () => {
+  const definitions = { Tail: { enum: ["x"] }, Loop: { allOf: [{ $ref: "#/definitions/Loop" }] } };
+  for (let index = 0; index < 6; index += 1) {
+    definitions[`Hop${index}`] = {
+      allOf: [{ $ref: index === 5 ? "#/definitions/Tail" : `#/definitions/Hop${index + 1}` }],
+    };
+  }
+  const schema = {
+    properties: {
+      sandbox_mode: { allOf: [{ $ref: "#/definitions/Hop0" }] },
+      web_search: { $ref: "#/definitions/Loop" },
+    },
+    definitions,
+  };
+  assert.deepEqual(resolveEnumMembers(schema, "sandbox_mode"), ["x"]);
+  assert.deepEqual(resolveEnumMembers(schema, "web_search"), []);
+});
+
+test("resolveEnumMembers returns nothing for an absent key", () => {
+  assert.deepEqual(resolveEnumMembers(refSchema(["read-only"]), "approval_policy"), []);
+});
+
+test("hookEventNames reads the real Claude schema", () => {
+  const schema = JSON.parse(readFileSync(claudeSchemaPath, "utf8"));
+  const events = hookEventNames(schema);
+  for (const event of ["PreToolUse", "PostToolUse", "SessionStart", "UserPromptSubmit"]) {
+    assert.ok(events.includes(event), `missing ${event}`);
+  }
+});
+
+// Claude already uses $defs elsewhere in this schema, so hooks moving behind a $ref is the likely
+// next shape — reading properties.hooks.properties literally would go blind exactly as jq did.
+test("hookEventNames follows a $ref on the hooks property", () => {
+  const schema = {
+    properties: { hooks: { $ref: "#/$defs/Hooks" } },
+    $defs: { Hooks: { properties: { PreToolUse: {}, SessionStart: {} } } },
+  };
+  assert.deepEqual(hookEventNames(schema), ["PreToolUse", "SessionStart"]);
+});
+
+test("codex enum drift reports added and removed members", () => {
+  const findings = findCodexEnumDrift(
+    refSchema(["danger-full-access", "read-only", "workspace-write"]),
+    refSchema(["read-only", "workspace-jail"]),
+    { sandbox_mode: "workspace-write" }
+  );
+  assert.deepEqual(findings, [
+    {
+      key: "sandbox_mode",
+      added: ["danger-full-access", "workspace-write"],
+      removed: ["workspace-jail"],
+    },
+  ]);
+});
+
+test("codex enum drift flags a hardcoded value the schema dropped", () => {
+  const findings = findCodexEnumDrift(refSchema(["read-only"]), refSchema(["read-only"]), {
+    sandbox_mode: "workspace-write",
+  });
+  assert.deepEqual(findings, [{ key: "sandbox_mode", stale: "workspace-write" }]);
+});
+
+// A newly added snapshot has no HEAD copy. The stale check reads only the current schema, so
+// losing the comparison baseline must not take it down with it.
+test("codex enum drift still flags a stale hardcoded value with no previous schema", () => {
+  const findings = findCodexEnumDrift(refSchema(["read-only"]), null, {
+    sandbox_mode: "workspace-write",
+  });
+  assert.deepEqual(findings, [{ key: "sandbox_mode", stale: "workspace-write" }]);
+});
+
+test("claude hook drift still flags a stale hardcoded event with no previous schema", () => {
+  const current = { properties: { hooks: { properties: { PreToolUse: {} } } } };
+  const findings = findClaudeHookDrift(current, null, ["PreToolUse", "SessionStart"]);
+  assert.deepEqual(findings, [{ key: "hooks", stale: "SessionStart" }]);
+});
+
+test("codex enum drift flags a watched key that vanished entirely", () => {
+  const findings = findCodexEnumDrift(
+    { properties: { approval_policy: {} } },
+    refSchema(["read-only"]),
+    { sandbox_mode: "workspace-write" }
+  );
+  assert.deepEqual(findings, [{ key: "sandbox_mode", missingKey: true }]);
+});
+
+// An empty properties map means the schema was not understood, not that upstream deleted the keys.
+test("codex enum drift does not claim keys vanished when no property is readable", () => {
+  assert.deepEqual(findCodexEnumDrift({}, null, { sandbox_mode: "workspace-write" }), []);
+});
+
+test("codex enum drift stays silent when the watched enum is unchanged", () => {
+  const schema = refSchema(["read-only", "workspace-write"]);
+  assert.deepEqual(findCodexEnumDrift(schema, schema, { sandbox_mode: "workspace-write" }), []);
+});
+
+test("claude hook drift flags a hardcoded event the schema dropped", () => {
+  const current = { properties: { hooks: { properties: { PreToolUse: {} } } } };
+  const previous = { properties: { hooks: { properties: { PreToolUse: {}, SessionStart: {} } } } };
+  const findings = findClaudeHookDrift(current, previous, ["PreToolUse", "SessionStart"]);
+  assert.deepEqual(findings, [
+    { key: "hooks", added: [], removed: ["SessionStart"] },
+    { key: "hooks", stale: "SessionStart" },
+  ]);
+});
+
+test("the shipped schemas keep every value the runtime hardcodes", () => {
+  const codex = JSON.parse(readFileSync(codexSchemaPath, "utf8"));
+  const claude = JSON.parse(readFileSync(claudeSchemaPath, "utf8"));
+  assert.deepEqual(findCodexEnumDrift(codex, codex), []);
+  assert.deepEqual(findClaudeHookDrift(claude, claude), []);
+});
+
+test("renderSection is empty when nothing drifted", () => {
+  assert.equal(renderSection([], []), "");
+});
+
+test("renderSection labels stale hardcoded values per host", () => {
+  const section = renderSection(
+    [{ key: "hooks", stale: "PreToolUse" }],
+    [{ key: "sandbox_mode", stale: "workspace-write" }]
+  );
+  assert.match(section, /## Compat scan — enum drift on watched keys/);
+  assert.match(section, /### Claude\n- \*\*STALE HARDCODED\*\* hook event `PreToolUse`/);
+  assert.match(section, /### Codex\n- \*\*STALE HARDCODED\*\* `sandbox_mode = "workspace-write"`/);
+});
+
+// Silence is how a reviewer concludes the scan ran and found nothing, so a skipped scan must say so.
+test("renderSection reports a schema it could not read instead of staying silent", () => {
+  const section = renderSection([], [{ unreadable: "snapshots/codex/config-schema.json" }]);
+  assert.match(section, /\*\*SCAN SKIPPED\*\* `snapshots\/codex\/config-schema\.json`/);
+});

--- a/tests/detect-enum-drift.test.mjs
+++ b/tests/detect-enum-drift.test.mjs
@@ -74,6 +74,52 @@ test("resolveEnumMembers survives a chain of wrappers and a $ref cycle", () => {
   assert.deepEqual(resolveEnumMembers(schema, "web_search"), []);
 });
 
+// allOf narrows and oneOf/anyOf widen. Unioning allOf branches reads a narrowed key as unchanged,
+// which is the false negative this guard exists to end.
+test("resolveEnumMembers intersects allOf branches instead of unioning them", () => {
+  const schema = {
+    properties: {
+      sandbox_mode: { allOf: [{ $ref: "#/definitions/SandboxMode" }, { enum: ["read-only"] }] },
+    },
+    definitions: { SandboxMode: { enum: ["danger-full-access", "read-only", "workspace-write"] } },
+  };
+  assert.deepEqual(resolveEnumMembers(schema, "sandbox_mode"), ["read-only"]);
+});
+
+test("codex enum drift flags a hardcoded value an allOf narrowed away", () => {
+  const wide = refSchema(["read-only", "workspace-write"]);
+  const narrowed = {
+    properties: {
+      sandbox_mode: { allOf: [{ $ref: "#/definitions/SandboxMode" }, { enum: ["read-only"] }] },
+    },
+    definitions: wide.definitions,
+  };
+  const findings = findCodexEnumDrift(narrowed, wide, { sandbox_mode: "workspace-write" });
+  assert.deepEqual(findings, [
+    { key: "sandbox_mode", added: [], removed: ["workspace-write"] },
+    { key: "sandbox_mode", stale: "workspace-write" },
+  ]);
+});
+
+// The runtime keeps writing its string into whatever the field became, so this is the loudest
+// signal available — not a reason to fall back to a plain "enum changed" bullet.
+test("codex enum drift flags a hardcoded value when the key stops being an enum", () => {
+  const findings = findCodexEnumDrift(
+    { properties: { sandbox_mode: { type: "boolean" } } },
+    refSchema(["read-only", "workspace-write"]),
+    { sandbox_mode: "workspace-write" }
+  );
+  assert.deepEqual(findings, [
+    { key: "sandbox_mode", added: [], removed: ["read-only", "workspace-write"] },
+    { key: "sandbox_mode", stale: "workspace-write" },
+  ]);
+});
+
+test("codex enum drift stays quiet for a key that was never an enum", () => {
+  const schema = { properties: { sandbox_mode: { type: "string" } } };
+  assert.deepEqual(findCodexEnumDrift(schema, schema, { sandbox_mode: "workspace-write" }), []);
+});
+
 test("resolveEnumMembers returns nothing for an absent key", () => {
   assert.deepEqual(resolveEnumMembers(refSchema(["read-only"]), "approval_policy"), []);
 });


### PR DESCRIPTION
Second of four PRs replacing #39.

## The bug

The guard is supposed to catch upstream dropping a value the runtime hardcodes — above all `sandbox_mode = "workspace-write"`, which `rules/agents-map.json` maps Claude tool sets onto. It has never reported anything, and could not have.

The extractor read `.properties[key].oneOf[].enum[]` and `.properties[key].enum[]`. Every watched key is an indirection:

```json
"sandbox_mode": { "allOf": [{ "$ref": "#/definitions/SandboxMode" }] }
```

`jq` does not follow `$ref`, so the member list came back empty every run. That emptied the added/removed comparison, and the `STALE HARDCODED` branch sat behind `[ -n "$curr" ]`, so it was skipped too. A green report meant nothing had been read.

## Why a script rather than fixing the jq

Shell buried in a `run:` block cannot be tested, which is why this went unnoticed. `scripts/detect-enum-drift.mjs` follows the pattern already set by `scripts/detect-model-drift.mjs`, and the workflow loses 65 lines.

## Hardening beyond the original bug

An adversarial review of the first draft (in #39) found these; each has a test:

- **Both `definitions` and `$defs`.** The hosts already disagree — Codex ships draft-07 `definitions`, Claude ships `$defs`. Hard-coding either would turn a generator bump into "every member removed" *plus* a silently skipped stale check.
- **`hooks` followed through `$ref`.** It is read literally today, but Claude already uses `$defs` elsewhere in that same file, so `"hooks": {"$ref": …}` is the likely next shape — and would reproduce the exact blindness this PR fixes.
- **`previous` is optional.** The stale check reads only the current schema. The workflow's `git add --intent-to-add` exists because a snapshot can be new, which is when `git show HEAD:` fails — tying the check to a readable HEAD copy would silence it precisely then. The deleted shell ran the two independently; the first draft did not.
- **Hops count `$ref` only.** Counting composition depth too made one `allOf`+`$ref` wrapper cost two of the budget. Visited refs are tracked so a cycle terminates.
- **Explicit `maxBuffer` on `git show`.** Node's 1 MiB default would silently fail on the Claude schema, already ~200 KB and growing.
- **`SCAN SKIPPED` on an unreadable schema.** An absent section is how a reviewer concludes the scan ran and found nothing, so silence is the wrong failure mode.
- **`KEY GONE` only when some property is readable.** Otherwise a schema restructure would claim all three watched keys were deleted upstream.

## Verification

- `npm test` — 379/379 (360 + 19 new).
- Real snapshots: `sandbox_mode` resolves to all three modes; a standing test fails if any hardcoded value leaves its enum.
- Ran the guard with `workspace-write` removed from the real schema → reports both the removal and `STALE HARDCODED`.
- Ran it with the snapshot file missing → emits `SCAN SKIPPED`, exit 0, reason on stderr.