### PR TITLE
fix(sync): stop term mapping from eating the head of a longer identifier

### DIFF
--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -3456,10 +3456,18 @@ function applyTermMappings(value, from, to) {
 
   literalReplacements.sort((left, right) => right.source.length - left.source.length);
   return literalReplacements.reduce(
-    (nextText, { source, target }) =>
-      nextText.replace(new RegExp(escapeRegExp(source), "g"), target),
+    (nextText, { source, target }) => nextText.replace(literalTermPattern(source), target),
     working
   );
+}
+
+// A term must not be eaten out of a longer identifier: "gpt-5.3-codex" inside "gpt-5.3-codex-spark",
+// "fable" inside "affable", "Opus 5" inside "Opus 5.1". \b cannot express this — it sits between "6"
+// and "-", so a version-shaped term still matches the head of a longer id. The dot rules are
+// asymmetric on purpose: a dot that continues a version ("5" then ".1") extends the identifier, but
+// a dot ending a sentence ("opus(latest).") does not.
+function literalTermPattern(source) {
+  return new RegExp(`(?<![\\w-]|\\w\\.)${escapeRegExp(source)}(?![\\w-]|\\.\\w)`, "g");
 }
 
 function terminologyRules(data) {

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -1589,6 +1589,59 @@ test("sync applies default terminology mappings to instructions", () => {
   );
 });
 
+// A term used to be replaced anywhere it appeared as a substring, so a model id that merely starts
+// with a mapped one came out truncated: "gpt-5.6-nano" became "opus-nano".
+test("sync leaves a longer model id alone when a mapped term is only its prefix", () => {
+  const fixture = createFixture();
+  writeFileSync(
+    join(fixture.project, "AGENTS.md"),
+    "Pin gpt-5.6-nano for volume and gpt-5.6 for hard work.\n"
+  );
+  writeFileSync(join(fixture.project, "CLAUDE.md"), "old\n");
+
+  runCli(
+    fixture,
+    ["sync", "--scope", "project", "--include", "instructions", "--apply"],
+    undefined,
+    {
+      AI_CONFIG_SYNC_HOST: "codex",
+    }
+  );
+
+  assert.equal(
+    readFileSync(join(fixture.project, "CLAUDE.md"), "utf8"),
+    "Pin gpt-5.6-nano for volume and opus for hard work.\n"
+  );
+});
+
+test("sync leaves an English word alone when a mapped term is only its tail", () => {
+  const fixture = createFixture();
+  writeFileSync(join(fixture.project, "CLAUDE.md"), "An Opusculum is not Opus.\n");
+  writeFileSync(join(fixture.project, "AGENTS.md"), "old\n");
+
+  runCli(fixture, ["sync", "--scope", "project", "--include", "instructions", "--apply"]);
+
+  assert.equal(
+    readFileSync(join(fixture.project, "AGENTS.md"), "utf8"),
+    "An Opusculum is not gpt-5.6.\n"
+  );
+});
+
+// The boundary must not swallow ordinary sentence punctuation — a trailing "." that ends a sentence
+// is not a version continuation the way the "." in "5.1" is.
+test("sync still maps a term that ends a sentence", () => {
+  const fixture = createFixture();
+  writeFileSync(join(fixture.project, "CLAUDE.md"), "Reasoning goes to opus4.8(latest).\n");
+  writeFileSync(join(fixture.project, "AGENTS.md"), "old\n");
+
+  runCli(fixture, ["sync", "--scope", "project", "--include", "instructions", "--apply"]);
+
+  assert.equal(
+    readFileSync(join(fixture.project, "AGENTS.md"), "utf8"),
+    "Reasoning goes to gpt-5.6.\n"
+  );
+});
+
 test("sync applies host target templates to generic host surfaces", () => {
   const fixture = createFixture();
   writeFileSync(


### PR DESCRIPTION
Third of four PRs replacing #39. Independent of the others, but the model-tier remap should land after this one — it adds tokens that make this hazard much worse.

## The bug

Literal term replacement matched anywhere in the text. Any string that merely *begins* with a mapped term came out truncated. Reproduced against the rules on `main` today:

```
"Pin gpt-5.6-nano for volume"  ->  "Pin opus-nano for volume"
"An Opusculum is not Opus"     ->  "An gpt-5.6culum is not gpt-5.6"
```

Sorting by length only resolves collisions between two *listed* terms. It does nothing when the longer string is not in the map at all — which is the normal case for a new vendor variant, exactly what this repo exists to track.

This runs on every instruction and skill body sync, and the vocab auto-fix path persists the result, so a mangled id is written to disk rather than merely displayed.

## Why not `\b`

`\b` sits between `6` and `-`, so `gpt-5.6` still matches the head of `gpt-5.6-nano`. The guard rejects a match flanked by a word character or a hyphen instead.

The dot needs asymmetric treatment because it plays both roles:

| text | term | outcome |
| --- | --- | --- |
| `Opus 5.1` | `Opus 5` | blocked — the dot continues a version |
| `opus4.8(latest).` | `opus4.8(latest)` | maps — the dot ends a sentence |

So a leading `word.` and a trailing `.word` block the match; a bare trailing dot does not.

## Verification

- `npm test` — 363/363 (360 + 3). No existing terminology mapping regressed.
- Confirmed the new tests have teeth: reverting to the unanchored regex fails exactly the two repro tests. The sentence-ending test passes either way by design — it guards against the fix over-reaching, not against the original bug.