### PR TITLE
chore(rules): point the model tiers at the shipping lineups

### DIFF
--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -7070,15 +7070,13 @@ function modelTiers() {
 function modelAliasMap(from, to) {
   const aliases = {};
   for (const tier of modelTiers()) {
-    const sourceAlias = tier?.[from]?.alias;
     const targetAlias = tier?.[to]?.alias;
-    if (
-      typeof sourceAlias === "string" &&
-      sourceAlias &&
-      typeof targetAlias === "string" &&
-      targetAlias
-    ) {
-      aliases[sourceAlias] = targetAlias;
+    if (typeof targetAlias !== "string" || !targetAlias) continue;
+    const sourceTerms = Array.isArray(tier?.[from]?.terms) ? tier[from].terms : [];
+    // terms carry superseded ids and vendor-tagged variants, so a frontmatter model written in any
+    // accepted spelling still converts. Later tiers win, which is how an overlay reclaims a token.
+    for (const token of [tier?.[from]?.alias, ...sourceTerms]) {
+      if (typeof token === "string" && token) aliases[token] = targetAlias;
     }
   }
   return aliases;

--- a/docs/customizing-rules.md
+++ b/docs/customizing-rules.md
@@ -298,8 +298,8 @@ Manages agent field mappings and model tier aliases. Use this when you want to a
           "terms": ["sonnet(latest)", "Claude Sonnet", "Sonnet", "standard model"]
         },
         "codex": {
-          "alias": "gpt-5.4",
-          "terms": ["GPT-5.4", "standard model"]
+          "alias": "gpt-5.6-luna",
+          "terms": ["GPT-5.6 Luna", "standard model"]
         }
       }
     ]
@@ -307,7 +307,7 @@ Manages agent field mappings and model tier aliases. Use this when you want to a
 }
 ```
 
-The `latest-frontier-model` and `small-fast-model` tiers and the `fields` array are kept as the bundle ships them.
+The `mythos-class-model`, `latest-frontier-model`, and `small-fast-model` tiers and the `fields` array are kept as the bundle ships them.
 
 **Recipe: add a new model tier**
 

--- a/docs/customizing-rules.md
+++ b/docs/customizing-rules.md
@@ -284,6 +284,8 @@ To force `hooks` to manual review and prevent automatic application:
 
 Manages agent field mappings and model tier aliases. Use this when you want to add a tier before the bundle ships it, or to attach in-house phrasing to an existing tier.
 
+A tier's `claude` and `codex` objects are replaced wholesale, not merged field by field. `terms` decide which model values convert, so an overlay that lists only its own spellings drops the bundled ones — a model written in a dropped spelling then passes through unconverted. Repeat the bundled `terms` you still want alongside yours.
+
 **Recipe: add an alias to the existing balanced-model tier**
 
 ```json
@@ -299,7 +301,7 @@ Manages agent field mappings and model tier aliases. Use this when you want to a
         },
         "codex": {
           "alias": "gpt-5.6-luna",
-          "terms": ["GPT-5.6 Luna", "standard model"]
+          "terms": ["gpt-5.4", "gpt-5.1-codex-mini", "GPT-5.6 Luna", "standard model"]
         }
       }
     ]

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -200,7 +200,9 @@ Model alias rules come from `rules/agents-map.json` `models.tiers` rather than t
 - `balanced-model` — `sonnet` ↔ `gpt-5.6-luna`
 - `small-fast-model` — `haiku` ↔ `gpt-5.4-mini`
 
-The `alias` is what conversion writes. Each tier's `terms` are also accepted as model values, so superseded ids (`gpt-5.6`, `gpt-5.5`, `gpt-5.4`) and vendor-tagged variants (`gpt-5.3-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`) resolve to a tier instead of passing through unmapped. A token may appear in only one tier; an overlay wins because its tiers merge in last.
+The `alias` is what conversion writes. Each tier's `terms` are also accepted as model values, so superseded ids (`gpt-5.6`, `gpt-5.5`, `gpt-5.4`, `gpt-5.2`) and vendor-tagged variants (`gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.1-codex`, `gpt-5-codex`) resolve to a tier instead of passing through unmapped. A token may appear in only one tier; an overlay wins because its tiers merge in last.
+
+Accepting a spelling also makes it equivalent. A Codex file pinned to `gpt-5.5` and a Claude file on `opus` are the same tier, so `status` reports them in sync and `sync` never rewrites the pin to `gpt-5.6-terra`. That is the trade-off for converting superseded ids at all: a spelling cannot both convert to a tier and conflict with it. Change the pin by hand if you want the canonical id on disk.
 
 ## Paraphrase
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -195,9 +195,12 @@ Hook, MCP, and web access vocabulary used in text instructions.
 
 Model alias rules come from `rules/agents-map.json` `models.tiers` rather than the terminology map.
 
-- `latest-frontier-model` — `opus` ↔ `gpt-5.5`
-- `balanced-model` — `sonnet` ↔ `gpt-5.4`
+- `mythos-class-model` — `fable` ↔ `gpt-5.6-sol`
+- `latest-frontier-model` — `opus` ↔ `gpt-5.6-terra`
+- `balanced-model` — `sonnet` ↔ `gpt-5.6-luna`
 - `small-fast-model` — `haiku` ↔ `gpt-5.4-mini`
+
+The `alias` is what conversion writes. Each tier's `terms` are also accepted as model values, so superseded ids (`gpt-5.6`, `gpt-5.5`, `gpt-5.4`) and vendor-tagged variants (`gpt-5.3-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`) resolve to a tier instead of passing through unmapped. A token may appear in only one tier; an overlay wins because its tiers merge in last.
 
 ## Paraphrase
 

--- a/rules/agents-map.json
+++ b/rules/agents-map.json
@@ -28,7 +28,7 @@
         "id": "mythos-class-model",
         "claude": {
           "alias": "fable",
-          "terms": ["fable(latest)", "Claude Fable 5", "Fable 5"]
+          "terms": ["fable(latest)", "Claude Fable 5", "Fable 5", "Fable"]
         },
         "codex": {
           "alias": "gpt-5.6-sol",
@@ -56,6 +56,9 @@
             "gpt-5.6",
             "gpt-5.5",
             "gpt-5.3-codex",
+            "gpt-5.2-codex",
+            "gpt-5.1-codex",
+            "gpt-5-codex",
             "gpt-5.1-codex-max",
             "gpt5.6(latest)",
             "gpt-5.6 latest",

--- a/rules/agents-map.json
+++ b/rules/agents-map.json
@@ -22,17 +22,48 @@
     }
   },
   "models": {
-    "description": "Single source of truth for model mapping. `alias` is the bare frontmatter token used by agent-frontmatter mapping. `terms` is the ordered synonym list for free-text terminology mapping (first term is the canonical replacement target).",
+    "description": "Single source of truth for model mapping. `alias` is the canonical token written into converted frontmatter and prose. `terms` are other accepted spellings of the same tier — every one is also a recognized frontmatter model value, which is how superseded ids and vendor-tagged variants still convert instead of passing through unmapped. A token may appear in only one tier; a project or user overlay wins because its tiers merge in last.",
     "tiers": [
+      {
+        "id": "mythos-class-model",
+        "claude": {
+          "alias": "fable",
+          "terms": ["fable(latest)", "Claude Fable 5", "Fable 5"]
+        },
+        "codex": {
+          "alias": "gpt-5.6-sol",
+          "terms": ["GPT-5.6 Sol", "GPT-5.6-Sol"]
+        }
+      },
       {
         "id": "latest-frontier-model",
         "claude": {
           "alias": "opus",
-          "terms": ["opus4.8(latest)", "opus 4.8 latest", "Claude Opus 4.8", "Opus 4.8", "Opus"]
+          "terms": [
+            "opus(latest)",
+            "opus4.8(latest)",
+            "opus 4.8 latest",
+            "Claude Opus 5",
+            "Claude Opus 4.8",
+            "Opus 5",
+            "Opus 4.8",
+            "Opus"
+          ]
         },
         "codex": {
-          "alias": "gpt-5.6",
-          "terms": ["gpt5.6(latest)", "gpt-5.6 latest", "GPT-5.6", "GPT 5.6"]
+          "alias": "gpt-5.6-terra",
+          "terms": [
+            "gpt-5.6",
+            "gpt-5.5",
+            "gpt-5.3-codex",
+            "gpt-5.1-codex-max",
+            "gpt5.6(latest)",
+            "gpt-5.6 latest",
+            "GPT-5.6 Terra",
+            "GPT-5.6-Terra",
+            "GPT-5.6",
+            "GPT 5.6"
+          ]
         }
       },
       {
@@ -42,15 +73,15 @@
           "terms": ["sonnet(latest)", "Claude Sonnet 5", "Claude Sonnet", "Sonnet 5", "Sonnet"]
         },
         "codex": {
-          "alias": "gpt-5.4",
-          "terms": ["GPT-5.4"]
+          "alias": "gpt-5.6-luna",
+          "terms": ["gpt-5.4", "gpt-5.1-codex-mini", "GPT-5.6 Luna", "GPT-5.6-Luna", "GPT-5.4"]
         }
       },
       {
         "id": "small-fast-model",
         "claude": {
           "alias": "haiku",
-          "terms": ["haiku(latest)", "Claude Haiku", "Haiku"]
+          "terms": ["haiku(latest)", "Claude Haiku 4.5", "Claude Haiku", "Haiku 4.5", "Haiku"]
         },
         "codex": {
           "alias": "gpt-5.4-mini",

--- a/rules/agents-map.json
+++ b/rules/agents-map.json
@@ -55,6 +55,7 @@
           "terms": [
             "gpt-5.6",
             "gpt-5.5",
+            "gpt-5.2",
             "gpt-5.3-codex",
             "gpt-5.2-codex",
             "gpt-5.1-codex",
@@ -77,7 +78,7 @@
         },
         "codex": {
           "alias": "gpt-5.6-luna",
-          "terms": ["gpt-5.4", "gpt-5.1-codex-mini", "GPT-5.6 Luna", "GPT-5.6-Luna", "GPT-5.4"]
+          "terms": ["gpt-5.4", "gpt-5.3-codex-spark", "gpt-5.1-codex-mini", "GPT-5.6 Luna", "GPT-5.6-Luna", "GPT-5.4"]
         }
       },
       {

--- a/scripts/detect-model-drift.mjs
+++ b/scripts/detect-model-drift.mjs
@@ -17,8 +17,8 @@ const PROSE_FILES = [
 // Stopwords are the inverse risk of an allowlist: a stopword that later becomes a real model name
 // silently misses it, so the lists stay tight, grounded, and HOST-SCOPED. Grammar words are never a
 // model in any position → global. Product/plan words were grounded in the "Claude <word>" slot
-// (Code appears 130×, Platform/API/Pro/Max/Desktop/Browser/Skills/Agent/Fable are Claude products,
-// plans, or an unmapped model) — but on the Codex side "Pro"/"Max" are REAL model tiers (GPT-5 Pro,
+// (Code appears 130×, Platform/API/Pro/Max/Desktop/Browser/Skills/Agent are Claude products or
+// plans) — but on the Codex side "Pro"/"Max" are REAL model tiers (GPT-5 Pro,
 // o1-pro), so applying them there would silently drop a new variant whose base tier is already known.
 // Hence product words apply to the claude patterns only. New names surface by default; cheap
 // human-review noise beats a silent miss (this is what let a tier bump slip through before).
@@ -44,7 +44,6 @@ const CLAUDE_PRODUCT_STOPWORDS = new Set([
   "browser",
   "skills",
   "agent",
-  "fable",
 ]);
 function isStopword(host, name) {
   if (!name) return false;

--- a/tests/agents-map.test.mjs
+++ b/tests/agents-map.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const agentsMapPath = join(here, "..", "rules", "agents-map.json");
+
+async function loadTiers() {
+  return JSON.parse(await readFile(agentsMapPath, "utf8")).models.tiers;
+}
+
+function tokensFor(tier, host) {
+  const side = tier[host] ?? {};
+  return [side.alias, ...(Array.isArray(side.terms) ? side.terms : [])].filter(Boolean);
+}
+
+test("agents-map tiers declare an alias for both hosts", async () => {
+  for (const tier of await loadTiers()) {
+    for (const host of ["claude", "codex"]) {
+      assert.equal(typeof tier[host]?.alias, "string", `${tier.id}.${host}.alias must be a string`);
+      assert.ok(tier[host].alias.length > 0, `${tier.id}.${host}.alias must be non-empty`);
+    }
+  }
+});
+
+// Every alias and term is a lookup key in modelAliasMap. A token claimed by two tiers resolves by
+// declaration order, so one tier silently loses — and an overlay that reuses a token would either
+// be ignored or capture one it did not mean to.
+test("no model token is claimed by two tiers", async () => {
+  const tiers = await loadTiers();
+  for (const host of ["claude", "codex"]) {
+    const owner = new Map();
+    for (const tier of tiers) {
+      for (const token of tokensFor(tier, host)) {
+        assert.equal(
+          owner.has(token),
+          false,
+          `${host} token ${JSON.stringify(token)} is in both ${owner.get(token)} and ${tier.id}`
+        );
+        owner.set(token, tier.id);
+      }
+    }
+  }
+});
+
+// The alias is what conversion writes, so it has to survive its own mapping unchanged.
+test("every alias round-trips back to itself", async () => {
+  const tiers = await loadTiers();
+  const aliasMap = (from, to) => {
+    const map = {};
+    for (const tier of tiers) {
+      for (const token of tokensFor(tier, from)) map[token] = tier[to].alias;
+    }
+    return map;
+  };
+  const forward = aliasMap("claude", "codex");
+  const backward = aliasMap("codex", "claude");
+  for (const tier of tiers) {
+    assert.equal(backward[forward[tier.claude.alias]], tier.claude.alias, `${tier.id} claude`);
+    assert.equal(forward[backward[tier.codex.alias]], tier.codex.alias, `${tier.id} codex`);
+  }
+});

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -657,7 +657,7 @@ test("default status details content differs sources", () => {
 test("instructions status treats terminology-mapped model names as equivalent", () => {
   const fixture = createFixture();
   writeFileSync(join(fixture.project, "CLAUDE.md"), "Use opus4.8(latest) for hard reasoning.\n");
-  writeFileSync(join(fixture.project, "AGENTS.md"), "Use gpt-5.6 for hard reasoning.\n");
+  writeFileSync(join(fixture.project, "AGENTS.md"), "Use gpt-5.6-terra for hard reasoning.\n");
 
   const report = JSON.parse(
     runCli(fixture, ["status", "--scope", "project", "--include", "instructions", "--json"])
@@ -812,16 +812,16 @@ test("status reports same-name skill content drift as a manual conflict", () => 
     /apply: ai-config-sync sync --scope project --include skills:review --apply/
   );
   assert.match(output, /- Codex current L2: Codex version/);
-  assert.match(output, /\+ After apply from Claude L2: model: gpt-5\.6/);
+  assert.match(output, /\+ After apply from Claude L2: model: gpt-5\.6-terra/);
   assert.match(
     readFileSync(statusDetailPath(output), "utf8"),
-    /\+ After apply from Claude L2: model: gpt-5\.6/
+    /\+ After apply from Claude L2: model: gpt-5\.6-terra/
   );
 });
 
 test("status treats skill as equivalent when transform and override jointly equalize content", () => {
   // Verifies skillDirsEquivalent's transform+override combined-path: SKILL.md
-  // diverges in BOTH a model token (opus <-> gpt-5.6, closed by terminology
+  // diverges in BOTH a model token (opus <-> gpt-5.6-terra, closed by terminology
   // transform) AND a free-prose line (closed only by an active paraphrase
   // override). Neither path alone makes them equal, but applied together they
   // must — otherwise the skill surfaces as a manual conflict.
@@ -834,11 +834,11 @@ test("status treats skill as equivalent when transform and override jointly equa
   mkdirSync(claudeSkill, { recursive: true });
   mkdirSync(codexSkill, { recursive: true });
 
-  // opus4.8(latest) <-> gpt-5.6 is a baked-in terminology mapping (agents-map.json
+  // opus4.8(latest) <-> gpt-5.6-terra is a baked-in terminology mapping (agents-map.json
   // models.tiers, latest-frontier-model). Used here to force one-directional
   // transform equivalence for the model-token line.
   const claudeBody = "# Jointly\nUse opus4.8(latest) for hard reasoning.\nRead the docs.\n";
-  const codexBody = "# Jointly\nUse gpt-5.6 for hard reasoning.\nInspect the docs.\n";
+  const codexBody = "# Jointly\nUse gpt-5.6-terra for hard reasoning.\nInspect the docs.\n";
   writeFileSync(join(claudeSkill, "SKILL.md"), claudeBody);
   writeFileSync(join(codexSkill, "SKILL.md"), codexBody);
 
@@ -886,7 +886,7 @@ test("status treats skill differing only by model alias as equivalent (no phanto
   );
   writeFileSync(
     join(fixture.project, ".agents/skills/aliased/SKILL.md"),
-    "---\nname: aliased\nmodel: gpt-5.6\n---\n# Aliased\nShared body.\n"
+    "---\nname: aliased\nmodel: gpt-5.6-terra\n---\n# Aliased\nShared body.\n"
   );
 
   const report = JSON.parse(
@@ -899,7 +899,7 @@ test("status treats skill differing by model alias plus a term-masked line as eq
   // Regression for #10 sibling path: maskedSkillContentHash transforms to the
   // host-native model alias but never folds it back to canonical the way
   // skillContentHash does. When a skill needs BOTH a term ignore rule (to mask a
-  // diverging prose line) AND the model fold, the masked hash ends on gpt-5.6 vs
+  // diverging prose line) AND the model fold, the masked hash ends on gpt-5.6-terra vs
   // canonical opus and the skill surfaces as a phantom manual conflict.
   const fixture = createFixture();
   writeSkillManifest(
@@ -919,7 +919,9 @@ test("status treats skill differing by model alias plus a term-masked line as eq
   writeSkillManifest(
     join(fixture.project, ".agents/skills/masked-alias"),
     "codex",
-    ["---", "name: masked-alias", "model: gpt-5.6", "---", "# X", "common line", ""].join("\n")
+    ["---", "name: masked-alias", "model: gpt-5.6-terra", "---", "# X", "common line", ""].join(
+      "\n"
+    )
   );
   mkdirSync(join(fixture.project, ".ai-config-sync-manager"), { recursive: true });
   writeJson(join(fixture.project, ".ai-config-sync-manager/status-ignore.json"), {
@@ -937,7 +939,7 @@ test("status treats skill differing by model alias plus an override-masked line 
   // Regression for #10 sibling path: overriddenTransformedSkillContentHash layers
   // transformTextForHost over paraphrase masking but never folds the model token
   // back to canonical. A skill needing BOTH a paraphrase override (to mask a
-  // diverging prose line) AND the model fold ends on gpt-5.6 vs canonical opus,
+  // diverging prose line) AND the model fold ends on gpt-5.6-terra vs canonical opus,
   // surfacing as a phantom manual conflict even though the prose is overridden.
   const fixture = createFixture();
   const projectReal = realpathSync(fixture.project);
@@ -951,7 +953,7 @@ test("status treats skill differing by model alias plus an override-masked line 
   );
   writeFileSync(
     join(codexSkill, "SKILL.md"),
-    "---\nname: override-alias\nmodel: gpt-5.6\n---\n# X\nInspect the docs.\n"
+    "---\nname: override-alias\nmodel: gpt-5.6-terra\n---\n# X\nInspect the docs.\n"
   );
   writeJson(join(fixture.home, ".ai-config-sync-manager/rules/paraphrase-overrides.json"), {
     version: 1,
@@ -1585,7 +1587,7 @@ test("sync applies default terminology mappings to instructions", () => {
   assert.match(output, /Target templates: .*rules\/host-target-templates\.json/);
   assert.equal(
     agents,
-    "Use AGENTS.md with gpt-5.6, reasoning effort, and Codex spawn_agent delegation.\n"
+    "Use AGENTS.md with gpt-5.6-terra, reasoning effort, and Codex spawn_agent delegation.\n"
   );
 });
 
@@ -1623,7 +1625,7 @@ test("sync leaves an English word alone when a mapped term is only its tail", ()
 
   assert.equal(
     readFileSync(join(fixture.project, "AGENTS.md"), "utf8"),
-    "An Opusculum is not gpt-5.6.\n"
+    "An Opusculum is not gpt-5.6-terra.\n"
   );
 });
 
@@ -1638,7 +1640,7 @@ test("sync still maps a term that ends a sentence", () => {
 
   assert.equal(
     readFileSync(join(fixture.project, "AGENTS.md"), "utf8"),
-    "Reasoning goes to gpt-5.6.\n"
+    "Reasoning goes to gpt-5.6-terra.\n"
   );
 });
 
@@ -1761,9 +1763,9 @@ test("sync apply replaces manual skill conflicts without per-operation approval"
   assert.match(output, /Change preview:/);
   assert.match(output, /review: target will be replaced from Claude/);
   assert.match(output, /- Target current L2: Codex version/);
-  assert.match(output, /\+ After apply from Claude L2: model: gpt-5\.6/);
+  assert.match(output, /\+ After apply from Claude L2: model: gpt-5\.6-terra/);
   assert.match(output, /replaced skill review/);
-  assert.equal(skill, "# Review\nmodel: gpt-5.6\n");
+  assert.equal(skill, "# Review\nmodel: gpt-5.6-terra\n");
 });
 
 test("sync apply normalizes model alias in frontmatter when copying skill claude->codex", () => {
@@ -1778,7 +1780,7 @@ test("sync apply normalizes model alias in frontmatter when copying skill claude
   const skill = readFileSync(join(fixture.project, ".agents/skills/review/SKILL.md"), "utf8");
 
   assert.match(skill, /^---\n/);
-  assert.match(skill, /\nmodel: gpt-5\.6\n/);
+  assert.match(skill, /\nmodel: gpt-5\.6-terra\n/);
   assert.doesNotMatch(skill, /\nmodel: opus\n/);
 });
 
@@ -1787,7 +1789,7 @@ test("sync apply normalizes model alias in frontmatter when copying skill codex-
   mkdirSync(join(fixture.project, ".agents/skills/review"), { recursive: true });
   writeFileSync(
     join(fixture.project, ".agents/skills/review/SKILL.md"),
-    "---\nname: review\nmodel: gpt-5.6\n---\n# Review\n\nBody.\n"
+    "---\nname: review\nmodel: gpt-5.6-terra\n---\n# Review\n\nBody.\n"
   );
 
   runCli(fixture, [
@@ -1806,7 +1808,7 @@ test("sync apply normalizes model alias in frontmatter when copying skill codex-
 
   assert.match(skill, /^---\n/);
   assert.match(skill, /\nmodel: opus\n/);
-  assert.doesNotMatch(skill, /\nmodel: gpt-5\.6\n/);
+  assert.doesNotMatch(skill, /\nmodel: gpt-5\.6-terra\n/);
 });
 
 test("sync applies terminology mappings when copying skills", () => {
@@ -1820,7 +1822,7 @@ test("sync applies terminology mappings when copying skills", () => {
   runCli(fixture, ["sync", "--scope", "project", "--include", "skills:review", "--apply"]);
   const skill = readFileSync(join(fixture.project, ".agents/skills/review/SKILL.md"), "utf8");
 
-  assert.equal(skill, "# Review\nUse AGENTS.md with gpt-5.6.\n");
+  assert.equal(skill, "# Review\nUse AGENTS.md with gpt-5.6-terra.\n");
 });
 
 test("sync applies host target templates when copying skills", () => {
@@ -2872,7 +2874,7 @@ test("agents sync apply copies Claude agent to Codex with model alias", () => {
   assert.match(output, /Backup root: /);
   assert.match(codexFile, /^name = "sample"$/m);
   assert.match(codexFile, /^description = "Example agent"$/m);
-  assert.match(codexFile, /^model = "gpt-5\.6"$/m);
+  assert.match(codexFile, /^model = "gpt-5\.6-terra"$/m);
   assert.match(codexFile, /developer_instructions = "[^"]*Hello, agent body\./);
 });
 
@@ -3336,11 +3338,11 @@ test("sync apply transforms TeamCreate call with flat named-args + members array
   assert.match(codexBody, /Use `multi_agent_v2\.spawn_agent` to launch the "review-team" team/);
   assert.match(
     codexBody,
-    /### Member: code \(agent_type: "browser-audit\/code-security-auditor", model: "gpt-5\.6"\)/
+    /### Member: code \(agent_type: "browser-audit\/code-security-auditor", model: "gpt-5\.6-terra"\)/
   );
   assert.match(
     codexBody,
-    /### Member: browser \(agent_type: "browser-audit\/browser-runtime-auditor", model: "gpt-5\.6"\)/
+    /### Member: browser \(agent_type: "browser-audit\/browser-runtime-auditor", model: "gpt-5\.6-terra"\)/
   );
   assert.doesNotMatch(codexBody, /TeamCreate\(/);
   assert.doesNotMatch(codexBody, /ai-config-sync:manual-review/);
@@ -3379,7 +3381,12 @@ test("sync apply round-trips Codex team-call marker back into Claude TeamCreate(
   const markerFields = {
     team_name: "review-team",
     members: [
-      { name: "code", agent_type: "browser-audit/code", model: "gpt-5.6", prompt: "Audit code." },
+      {
+        name: "code",
+        agent_type: "browser-audit/code",
+        model: "gpt-5.6-terra",
+        prompt: "Audit code.",
+      },
     ],
   };
   const markerPayload = JSON.stringify({ call: "TeamCreate", fields: markerFields });
@@ -3391,7 +3398,7 @@ test("sync apply round-trips Codex team-call marker back into Claude TeamCreate(
       `<!-- ai-config-sync:team-call ${markerPayload} -->`,
       'Use `multi_agent_v2.spawn_agent` to launch the "review-team" team. Each member runs in parallel.',
       "",
-      '### Member: code (agent_type: "browser-audit/code", model: "gpt-5.6")',
+      '### Member: code (agent_type: "browser-audit/code", model: "gpt-5.6-terra")',
       "Audit code.",
       "",
       "",
@@ -6094,7 +6101,7 @@ test("sync applies layered partial merge to agents-map: model tier id override e
   runCli(fixture, ["sync", "--scope", "project", "--include", "instructions", "--apply"]);
   const agents = readFileSync(join(fixture.project, "AGENTS.md"), "utf8");
 
-  assert.equal(agents, "Use gpt-5.5 today and gpt-5.4 for chat.\n");
+  assert.equal(agents, "Use gpt-5.5 today and gpt-5.6-luna for chat.\n");
 });
 
 // ---------------------------------------------------------------------------
@@ -6592,7 +6599,7 @@ test("status surfaces vocab-mismatch when claude agent body uses spawn_agent", (
   writeCodexAgent(join(fixture.home, ".codex/agents/sample.toml"), {
     name: "sample",
     description: "demo agent",
-    model: "gpt-5.6",
+    model: "gpt-5.6-terra",
     developer_instructions: "spawn_agent를 호출한다.\n",
   });
 

--- a/tests/detect-model-drift.test.mjs
+++ b/tests/detect-model-drift.test.mjs
@@ -46,8 +46,21 @@ test("stale tier surfaces when Opus bumps past the recorded version", () => {
   assert.match(drift[0].note, /갱신/);
 });
 
-test("Fable is intentionally excluded from detection", () => {
-  assert.deepEqual(findModelDrift("Meet Claude Fable 5, a creative-writing model.", TIERS), []);
+// Fable was stopworded as a product name. Fable 5 shipped as a real tier, and the stopword meant
+// every changelog mention of it was dropped instead of reported — which is how the missing tier
+// stayed invisible through several drift reviews.
+test("Fable surfaces as drift while it is missing from the tiers", () => {
+  const drift = findModelDrift("Meet Claude Fable 5, a Mythos-class model.", TIERS);
+  assert.equal(drift.length, 1);
+  assert.equal(drift[0].raw, "Claude Fable 5");
+});
+
+test("Fable stays silent once a tier claims it", () => {
+  const tiers = [
+    { id: "mythos-class-model", claude: { alias: "fable", terms: ["Claude Fable 5", "Fable 5"] } },
+    ...TIERS,
+  ];
+  assert.deepEqual(findModelDrift("Meet Claude Fable 5, a Mythos-class model.", tiers), []);
 });
 
 test("hyphenated model ids are extracted", () => {


### PR DESCRIPTION
Fourth of four PRs replacing #39. **Targets #42**, not `main` — the word-boundary fix has to land first, because this adds tokens that would otherwise be eaten out of longer ids (`gpt-5.3-codex` inside `gpt-5.3-codex-spark`, `fable` inside `affable`).

## What was wrong

`model: fable` was copied to Codex verbatim — `modelAliasMap` leaves an unknown token untouched, and Codex has no such model.

Checking that turned up more: `gpt-5.4` is a generation behind and `gpt-5.4-mini` with it, but the balanced and small tiers still named them, and the Claude side still read "Opus 4.8" after Opus 5 shipped.

## The mapping

The two lineups line up rank for rank — Fable 5 sits above Opus in the Mythos class the way Sol leads GPT-5.6:

| tier | Claude | Codex |
| --- | --- | --- |
| `mythos-class-model` (new) | `fable` | `gpt-5.6-sol` |
| `latest-frontier-model` | `opus` | `gpt-5.6-terra` |
| `balanced-model` | `sonnet` | `gpt-5.6-luna` |
| `small-fast-model` | `haiku` | `gpt-5.4-mini` |

Haiku keeps `gpt-5.4-mini` because GPT-5.6 stops at three tiers.

Sources: [Claude models overview](https://platform.claude.com/docs/en/about-claude/models/overview), [Codex models](https://developers.openai.com/codex/models), [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol).

## Bare `gpt-5.6` deliberately stays on Opus

Upstream routes the bare alias to Sol, so the semantically pure choice is `gpt-5.6 → fable`. This does not do that.

This tool wrote `gpt-5.6` into every Codex file it converted from `model: opus`. Resolving it to `fable` would silently move those users onto a model priced well above the one they picked, and would break the status-side equivalence that currently holds between `opus` and `gpt-5.6` — turning every such pair into a phantom conflict. The precise `gpt-5.6-sol` still resolves to `fable`.

## Terms became lookup keys

`modelAliasMap` now keys off each tier's `terms` as well, so superseded ids (`gpt-5.6`, `gpt-5.5`, `gpt-5.4`) and vendor-tagged coding variants (`gpt-5.3-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`) resolve to a tier instead of passing through unmapped. Reusing `terms` avoids a second list to keep in sync.

Tokens must be unique across tiers — `tests/agents-map.test.mjs` enforces that. That invariant is what lets the lookup keep its original last-wins semantics: a project or user overlay merges in last, so it can still reclaim a token. A first-wins guard (which #39 had) would have made overlays silently ineffective.

## Why nobody noticed the missing tier

`scripts/detect-model-drift.mjs` listed `fable` among the Claude product words, so every changelog mention of Fable 5 was dropped before it could be reported. Removed, with the "intentionally excluded" test inverted into a pair: Fable surfaces while no tier claims it, and goes quiet once one does.

## Verification

- `npm test` — 367/367.
- New `tests/agents-map.test.mjs`: both hosts have an alias, no token is claimed by two tiers, every alias round-trips to itself.
- Checked the resulting map directly: `gpt-5.6 → opus`, `gpt-5.6-sol → fable`, `gpt-5.3-codex → opus`, `gpt-5.4 → sonnet`.
- Fixture churn in `cli-fixtures.test.mjs` is the canonical write target moving from `gpt-5.6` to `gpt-5.6-terra`. The prefix-boundary test from #42 keeps a bare `gpt-5.6` input on purpose, since that token is still mapped and still needs the guard.

## Upgrade impact

Model values get rewritten on the next sync: a Claude agent with `model: opus` previously produced `gpt-5.6` on the Codex side and now produces `gpt-5.6-terra`; `sonnet` moves from `gpt-5.4` to `gpt-5.6-luna`. Existing files are untouched until a sync writes them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Mythos-class model tier.
  * Expanded recognized Claude and Codex model names, aliases, and newer Haiku variants.
  * Updated frontier and balanced model aliases.

* **Bug Fixes**
  * Improved model mapping precedence and alias consistency.
  * Model drift detection now correctly reports previously excluded Fable model references.

* **Documentation**
  * Updated model references, customization guidance, accepted model identifiers, and tier equivalence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->