### PR TITLE
chore(compat): write the drift PR body in English

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # 액션 SHA 핀 자동 갱신 — 오염된 액션 차단의 핵심
+  # Keeps the action SHA pins current; a stale pin is what lets a compromised action through.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/scripts/detect-model-drift.mjs
+++ b/scripts/detect-model-drift.mjs
@@ -107,10 +107,10 @@ function claudeTier(key, tiers) {
 }
 
 function tierHint(candidate, tiers) {
-  if (candidate.host === "codex") return { tierId: null, note: "codex tier 확인 필요" };
+  if (candidate.host === "codex") return { tierId: null, note: "needs a codex tier decision" };
   const tier = claudeTier(candidate.key, tiers);
-  if (!tier) return { tierId: null, note: "새 tier 후보" };
-  return { tierId: tier.id, note: "기존 tier terms 갱신 권장" };
+  if (!tier) return { tierId: null, note: "candidate for a new tier" };
+  return { tierId: tier.id, note: "add to this tier's terms" };
 }
 
 export function findModelDrift(text, tiers) {
@@ -123,14 +123,14 @@ export function findModelDrift(text, tiers) {
 export function renderSection(candidates) {
   if (candidates.length === 0) return "";
   const lines = candidates.map((c) => {
-    const tier = c.tierId ? `추정 tier: ${c.tierId}` : c.note;
+    const tier = c.tierId ? `likely tier: ${c.tierId}` : c.note;
     return `- \`${c.raw}\` (${tier})${c.tierId ? ` — ${c.note}` : ""}`;
   });
   return [
     "",
-    "## Model drift — agents-map.models.tiers 갱신 필요",
+    "## Model drift — agents-map.models.tiers needs review",
     "",
-    "신규 모델 후보 (스키마에 없어 구조 스캔이 놓침). `rules/agents-map.json` `models.tiers` 확인:",
+    "New model candidates, named only in changelog prose, so the schema scan misses them. Check `rules/agents-map.json` `models.tiers`:",
     "",
     ...lines,
     "",

--- a/tests/detect-model-drift.test.mjs
+++ b/tests/detect-model-drift.test.mjs
@@ -43,7 +43,7 @@ test("stale tier surfaces when Opus bumps past the recorded version", () => {
   const drift = findModelDrift(prose, TIERS);
   assert.equal(drift.length, 1);
   assert.equal(drift[0].tierId, "latest-frontier-model");
-  assert.match(drift[0].note, /갱신/);
+  assert.match(drift[0].note, /terms/);
 });
 
 test("Fable is intentionally excluded from detection", () => {


### PR DESCRIPTION
The weekly upstream-compat workflow generates its PR body from `scripts/detect-model-drift.mjs`, and the model-drift section was written in Korean while the rest of the report — checklist, uncovered keys, enum drift — was English. That body is a repo artifact: it is what a reviewer, a future contributor, and CodeRabbit all read when triaging drift, so the one Korean section was the odd one out.

Translated the four strings that reach the body:

| before | after |
|---|---|
| `codex tier 확인 필요` | `needs a codex tier decision` |
| `새 tier 후보` | `candidate for a new tier` |
| `기존 tier terms 갱신 권장` | `add to this tier's terms` |
| `추정 tier: <id>` | `likely tier: <id>` |

plus the section heading and its lead-in sentence.

`tests/detect-model-drift.test.mjs:46` asserted on the Korean substring, so it moves with the string. The `.github/dependabot.yml` header comment was the only other Korean left outside test fixtures and goes along for the same reason. The Korean in `tests/cli-fixtures.test.mjs` stays — that is fixture content being converted, not repo prose.

Verified by rendering a section against `rules/agents-map.json`:

```
## Model drift — agents-map.models.tiers needs review

New model candidates, named only in changelog prose, so the schema scan misses them. Check `rules/agents-map.json` `models.tiers`:

- `Claude Opus 5` (likely tier: latest-frontier-model) — add to this tier's terms
- `gpt-9.9-zeta` (needs a codex tier decision)
```

`npm test`: 360 pass, 0 fail. No Korean left in `scripts/`, `.github/`, or non-fixture tests.