### PR TITLE
fix(mcp): preserve http_headers and dedup orphan sub-tables on codex sync

### DIFF
--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -5301,12 +5301,15 @@ function stripTopLevelMcpServerTables(text, serverNames, blockName = "mcp-server
 
 function stripMcpTablesFromSegment(segment, serverNames) {
   return serverNames.reduce((acc, name) => {
-    // Match `[mcp_servers.X]` headers (NOT `[mcp_servers.X.tools.Y]` sub-tables —
-    // those carry standalone tool-permission config the user may want to keep). The
+    // Match `[mcp_servers.X]` AND config sub-tables like `[mcp_servers.X.env]` /
+    // `[mcp_servers.X.http_headers]` — the managed block re-emits those fields inline,
+    // so leaving the standalone sub-table behind produces a duplicate TOML key that
+    // Codex's strict parser rejects. `[mcp_servers.X.tools.Y]` sub-tables are skipped
+    // (negative lookahead): they carry standalone tool-permission config to keep. The
     // body match consumes lines until the next TOML header (`[`) or a managed-block
     // marker (`# BEGIN/END ai-config-sync`), so it never accidentally swallows them.
     const pattern = new RegExp(
-      `(^|\\n)\\[mcp_servers\\.${escapeRegExp(name)}\\][^\\n]*(?:\\n(?!\\[|# (?:BEGIN|END) ai-config-sync )[^\\n]*)*\\n?`,
+      `(^|\\n)\\[mcp_servers\\.${escapeRegExp(name)}(?:\\.(?!tools[.\\]])[^\\]]+)?\\][^\\n]*(?:\\n(?!\\[|# (?:BEGIN|END) ai-config-sync )[^\\n]*)*\\n?`,
       "g"
     );
     return acc.replace(pattern, (match, prefix) => (prefix === "\n" ? "\n" : ""));
@@ -5804,12 +5807,14 @@ function readCodexMcpServerDetails(path) {
     const url = body.match(/^url\s*=\s*"([^"]*)"/m);
     const args = body.match(/^args\s*=\s*(\[.*\])/m);
     const env = body.match(/^env\s*=\s*(\{.*\})/m);
+    const httpHeaders = body.match(/^http_headers\s*=\s*(\{.*\})/m);
     const bearerTokenEnvVar = body.match(/^bearer_token_env_var\s*=\s*"([^"]*)"/m);
 
     if (command) server.command = command[1];
     if (url) server.url = url[1];
     if (args) server.args = parseJsonLike(args[1], []);
     if (env) server.env = parseInlineTomlObject(env[1]);
+    if (httpHeaders) server.headers = parseInlineTomlObject(httpHeaders[1]);
     if (bearerTokenEnvVar) server.bearerTokenEnvVar = bearerTokenEnvVar[1];
     servers[match[1]] = server;
   }
@@ -5849,12 +5854,14 @@ function readCodexMcpServers(path) {
     const url = body.match(/^url\s*=\s*"([^"]*)"/m);
     const args = body.match(/^args\s*=\s*(\[.*\])/m);
     const env = body.match(/^env\s*=\s*(\{.*\})/m);
+    const httpHeaders = body.match(/^http_headers\s*=\s*(\{.*\})/m);
     const bearerTokenEnvVar = body.match(/^bearer_token_env_var\s*=\s*"([^"]*)"/m);
 
     if (command) server.command = command[1];
     if (url) server.url = url[1];
     if (args) server.args = parseJsonLike(args[1], []);
     if (env) server.env = parseInlineTomlObject(env[1]);
+    if (httpHeaders) server.headers = parseInlineTomlObject(httpHeaders[1]);
     if (bearerTokenEnvVar) server.bearerTokenEnvVar = bearerTokenEnvVar[1];
     servers[match[1]] = server;
   }
@@ -6006,6 +6013,15 @@ function renderCodexMcpServers(servers) {
     if (server.env && Object.keys(server.env).length > 0) {
       lines.push(
         `env = { ${Object.entries(server.env)
+          .map(([key, value]) => `${key} = ${JSON.stringify(value)}`)
+          .join(", ")} }`
+      );
+    }
+    // Non-Authorization headers (e.g. an API key) map to Codex `http_headers`;
+    // omitting them silently drops the credential a streamable-http server needs.
+    if (server.headers && Object.keys(server.headers).length > 0) {
+      lines.push(
+        `http_headers = { ${Object.entries(server.headers)
           .map(([key, value]) => `${key} = ${JSON.stringify(value)}`)
           .join(", ")} }`
       );

--- a/bin/ai-config-sync.mjs
+++ b/bin/ai-config-sync.mjs
@@ -5312,7 +5312,18 @@ function stripMcpTablesFromSegment(segment, serverNames) {
       `(^|\\n)\\[mcp_servers\\.${escapeRegExp(name)}(?:\\.(?!tools[.\\]])[^\\]]+)?\\][^\\n]*(?:\\n(?!\\[|# (?:BEGIN|END) ai-config-sync )[^\\n]*)*\\n?`,
       "g"
     );
-    return acc.replace(pattern, (match, prefix) => (prefix === "\n" ? "\n" : ""));
+    // Loop to a fixed point rather than a single replace(): when a base table is
+    // immediately followed (only a blank line apart) by its own `.env`/`.http_headers`
+    // sub-table, the base match's trailing `\n?` consumes the separator newline the
+    // sub-table's own `(^|\n)` anchor needs, so a single pass leaves it unstripped.
+    // Re-running finds it anchored on the fresh `^` at the top of the shortened string.
+    let next = acc;
+    let previous;
+    do {
+      previous = next;
+      next = previous.replace(pattern, (match, prefix) => (prefix === "\n" ? "\n" : ""));
+    } while (next !== previous);
+    return next;
   }, segment);
 }
 
@@ -5482,11 +5493,22 @@ function deleteCodexMcpServers(targetPath, serverNames) {
       `^\\[mcp_servers\\.${escapeRegExp(name)}\\]\\n[\\s\\S]*?(?=^\\[mcp_servers\\.|(?![\\s\\S]))`,
       "gm"
     );
+    // `serverPattern`'s body match halts right before the next `[mcp_servers.` line,
+    // so a deleted server's own `.env`/`.http_headers` sub-tables (which start with
+    // that same prefix) are never swallowed by it. Strip them explicitly here — a
+    // fully-deleted server shouldn't leave its secrets behind in an orphan sub-table.
+    const configSubTablePattern = new RegExp(
+      `^\\[mcp_servers\\.${escapeRegExp(name)}\\.(?!tools\\.)[^\\]]+\\]\\n[\\s\\S]*?(?=^\\[mcp_servers\\.|(?![\\s\\S]))`,
+      "gm"
+    );
     const toolsPattern = new RegExp(
       `^\\[mcp_servers\\.${escapeRegExp(name)}\\.tools\\.[^\\]]+\\]\\n[\\s\\S]*?(?=^\\[|(?![\\s\\S]))`,
       "gm"
     );
-    nextText = nextText.replace(serverPattern, "").replace(toolsPattern, "");
+    nextText = nextText
+      .replace(serverPattern, "")
+      .replace(configSubTablePattern, "")
+      .replace(toolsPattern, "");
   }
 
   writeFileSync(targetPath, nextText.replace(/\n{3,}/g, "\n\n").replace(/\s*$/, "\n"));

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -314,6 +314,99 @@ test("global MCP sync maps Claude Authorization header to Codex bearer_token_env
   assert.equal(report.entries.length, 0);
 });
 
+test("global MCP sync preserves non-Authorization http headers as Codex http_headers", () => {
+  // Streamable-http servers carry custom headers (e.g. an API key) that are not a
+  // Bearer token. These must round-trip into Codex as `http_headers`, otherwise the
+  // synced server loses its credential and Codex cannot authenticate.
+  const fixture = createFixture();
+  mkdirSync(join(fixture.home, ".codex"), { recursive: true });
+  writeJson(join(fixture.home, ".claude.json"), {
+    mcpServers: {
+      context7: {
+        type: "http",
+        url: "https://mcp.context7.com/mcp",
+        headers: { CONTEXT7_API_KEY: "ctx7sk-test-key" },
+      },
+    },
+  });
+  writeFileSync(join(fixture.home, ".codex/config.toml"), "");
+
+  const output = runCli(fixture, [
+    "sync",
+    "--scope",
+    "global",
+    "--include",
+    "mcp:context7",
+    "--from",
+    "claude",
+    "--to",
+    "codex",
+    "--apply",
+  ]);
+  const config = readFileSync(join(fixture.home, ".codex/config.toml"), "utf8");
+
+  assert.match(output, /merged MCP servers claude -> codex: context7/);
+  assert.match(config, /\[mcp_servers\.context7\]/);
+  assert.match(config, /http_headers = \{ CONTEXT7_API_KEY = "ctx7sk-test-key" \}/);
+
+  // Reading the rendered header back must report parity, otherwise status loops forever.
+  const report = JSON.parse(
+    runCli(fixture, ["status", "--scope", "global", "--include", "mcp:context7", "--json"])
+  );
+  assert.equal(report.entries.length, 0);
+});
+
+test("global MCP sync strips a pre-existing [mcp_servers.X.env] sub-table so the merge does not duplicate keys", () => {
+  // A hand-placed env-only sub-table outside the managed block defines the same
+  // `mcp_servers.X.env` key the managed block re-emits inline. Without stripping it,
+  // Codex's strict TOML parser rejects the file with a duplicate-key error.
+  const fixture = createFixture();
+  mkdirSync(join(fixture.home, ".codex"), { recursive: true });
+  writeFileSync(
+    join(fixture.home, ".codex/config.toml"),
+    [
+      "[mcp_servers.databar.env]",
+      'DATABAR_API_KEY = "stale-value"',
+      "",
+      "[mcp_servers.databar.tools.search]",
+      "enabled = true",
+      "",
+    ].join("\n")
+  );
+  writeJson(join(fixture.home, ".claude.json"), {
+    mcpServers: {
+      databar: {
+        command: "node",
+        args: ["databar.js"],
+        env: { DATABAR_API_KEY: "fresh-value" },
+      },
+    },
+  });
+
+  runCli(fixture, [
+    "sync",
+    "--scope",
+    "global",
+    "--include",
+    "mcp:databar",
+    "--from",
+    "claude",
+    "--to",
+    "codex",
+    "--apply",
+  ]);
+  const config = readFileSync(join(fixture.home, ".codex/config.toml"), "utf8");
+
+  const count = (re) => (config.match(re) ?? []).length;
+  // The orphan env sub-table must be gone (the managed block owns env inline now).
+  assert.equal(count(/^\[mcp_servers\.databar\.env\]/gm), 0);
+  // Exactly one canonical table for the server — no duplicate definition.
+  assert.equal(count(/^\[mcp_servers\.databar\]/gm), 1);
+  assert.match(config, /env = \{ DATABAR_API_KEY = "fresh-value" \}/);
+  // Tool-permission sub-tables are user config the merge must preserve.
+  assert.match(config, /^\[mcp_servers\.databar\.tools\.search\]/m);
+});
+
 test("global MCP status reports parity when ~/.claude.json and codex config.toml hold the same server", () => {
   // ~/.claude.json is the only canonical Claude global MCP source; settings.json
   // and the legacy ~/.claude/mcp.json must not be probed.

--- a/tests/cli-fixtures.test.mjs
+++ b/tests/cli-fixtures.test.mjs
@@ -407,6 +407,105 @@ test("global MCP sync strips a pre-existing [mcp_servers.X.env] sub-table so the
   assert.match(config, /^\[mcp_servers\.databar\.tools\.search\]/m);
 });
 
+test("global MCP sync strips an adjacent [mcp_servers.X.env] sub-table that directly follows the base table", () => {
+  // Regression for a strip-regex bug: when a server's own base table is directly
+  // followed (one blank line apart) by its `.env` sub-table, the base table's
+  // greedy trailing match consumed the separator the sub-table needed as its own
+  // anchor, leaving the sub-table (and its secret) unstripped and producing a
+  // duplicate-key config.toml on the next merge.
+  const fixture = createFixture();
+  mkdirSync(join(fixture.home, ".codex"), { recursive: true });
+  writeFileSync(
+    join(fixture.home, ".codex/config.toml"),
+    [
+      "[mcp_servers.databar]",
+      'command = "node"',
+      'args = ["databar.js"]',
+      "",
+      "[mcp_servers.databar.env]",
+      'DATABAR_API_KEY = "stale-value"',
+      "",
+      "[mcp_servers.databar.http_headers]",
+      'X-Extra = "stale-header"',
+      "",
+    ].join("\n")
+  );
+  writeJson(join(fixture.home, ".claude.json"), {
+    mcpServers: {
+      databar: {
+        command: "node",
+        args: ["databar.js"],
+        env: { DATABAR_API_KEY: "fresh-value" },
+      },
+    },
+  });
+
+  runCli(fixture, [
+    "sync",
+    "--scope",
+    "global",
+    "--include",
+    "mcp:databar",
+    "--from",
+    "claude",
+    "--to",
+    "codex",
+    "--apply",
+  ]);
+  const config = readFileSync(join(fixture.home, ".codex/config.toml"), "utf8");
+
+  const count = (re) => (config.match(re) ?? []).length;
+  assert.equal(count(/^\[mcp_servers\.databar\.env\]/gm), 0);
+  assert.equal(count(/^\[mcp_servers\.databar\.http_headers\]/gm), 0);
+  assert.equal(count(/^\[mcp_servers\.databar\]/gm), 1);
+  assert.match(config, /env = \{ DATABAR_API_KEY = "fresh-value" \}/);
+});
+
+test("project MCP delete removes a server's orphan .env/.http_headers sub-tables, not just its base table", () => {
+  // Regression: deleteCodexMcpServers's lazy body match halts right before ANY
+  // `[mcp_servers.` line (including the deleted server's own sub-tables), so a
+  // "deleted" server used to leave its secrets behind in an orphan sub-table.
+  const fixture = createFixture();
+  mkdirSync(join(fixture.project, ".claude"), { recursive: true });
+  mkdirSync(join(fixture.project, ".codex"), { recursive: true });
+  writeFileSync(
+    join(fixture.project, ".codex/config.toml"),
+    [
+      "[mcp_servers.databar]",
+      'command = "node"',
+      "",
+      "[mcp_servers.databar.env]",
+      'DATABAR_API_KEY = "secret-value"',
+      "",
+      "[mcp_servers.other]",
+      'command = "npx"',
+      "",
+    ].join("\n")
+  );
+  writeJson(join(fixture.project, ".mcp.json"), {
+    mcpServers: {
+      other: { command: "npx" },
+    },
+  });
+
+  runCli(fixture, [
+    "sync",
+    "--scope",
+    "project",
+    "--include",
+    "mcp:databar",
+    "--from",
+    "claude",
+    "--to",
+    "codex",
+    "--apply",
+  ]);
+  const config = readFileSync(join(fixture.project, ".codex/config.toml"), "utf8");
+
+  assert.doesNotMatch(config, /databar/);
+  assert.match(config, /\[mcp_servers\.other\]/);
+});
+
 test("global MCP status reports parity when ~/.claude.json and codex config.toml hold the same server", () => {
   // ~/.claude.json is the only canonical Claude global MCP source; settings.json
   // and the legacy ~/.claude/mcp.json must not be probed.


### PR DESCRIPTION
## Problem

Four related bugs in the claude→codex MCP sync produce a `config.toml` that Codex's strict TOML parser rejects (duplicate keys), or that silently loses data:

1. **Dropped HTTP headers.** `renderCodexMcpServers` only carried the `Authorization` header over. Any streamable-http server authenticated via another header (e.g. context7's `CONTEXT7_API_KEY`) silently lost its API key on sync. Because the codex readers also didn't parse those headers back, `status` reported permanent drift and every sync re-applied the same broken change.

2. **Duplicate keys from orphan sub-tables.** `stripMcpTablesFromSegment` matched only `[mcp_servers.X]` headers, so pre-existing `[mcp_servers.X.env]` / `[mcp_servers.X.http_headers]` sub-tables survived outside the managed block. The managed block then re-emitted those fields inline — a duplicate key, which strict TOML rejects.

3. **Adjacent sub-table escapes the strip.** Even with (2) fixed, when a base table is directly followed by its own sub-table, the base match's trailing newline consumes the anchor the sub-table's `(^|\n)` needs, so a single `replace()` pass leaves it unstripped.

4. **Delete leaves secrets behind.** `deleteCodexMcpServers` removed the base table and `.tools` tables but not `.env`/`.http_headers` sub-tables, so a deleted server's secrets stayed in the file as orphan tables.

## Fix

- Emit non-Authorization headers as inline `http_headers` on the managed server entry, and teach both codex readers to parse it back so `status` reaches parity instead of looping.
- Strip non-`tools` config sub-tables when replacing a managed server, preserving `[mcp_servers.X.tools.Y]` permission tables via a negative lookahead.
- Loop the strip `replace()` to a fixed point to catch the adjacent-sub-table case.
- Explicitly strip a deleted server's config sub-tables in `deleteCodexMcpServers`.

## Tests

Four regression tests in `tests/cli-fixtures.test.mjs`, one per case above. Each was verified to fail against the pre-fix code. Full suite passes (`npm test`), lint and `npm run check` clean.
