### PR TITLE
fix(husky): a detached HEAD is not "a branch that is not main"

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,14 @@
 # Step 0: Guard against package.json version bumps outside main
 # Version bumps must be committed as a dedicated release commit on main.
 BRANCH=$(git branch --show-current)
-if [ "$BRANCH" != "main" ] && git diff --cached --name-only | grep -q "^package.json$"; then
+# `git branch --show-current` prints NOTHING when HEAD is detached, so the empty string was
+# being read as "a branch that is not main". Any flow that stages a version change with a
+# detached HEAD — validating a merge in a throwaway worktree, an interactive rebase, a
+# bisect — was refused with `on branch ''`, naming a branch nobody chose.
+#
+# The intent is unchanged: a version bump must not ride along on a NAMED feature branch. A
+# detached HEAD is a validation or rebase context, not a path a person releases from.
+if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && git diff --cached --name-only | grep -q "^package.json$"; then
   if git diff --cached package.json | grep -qE '^[+-][[:space:]]*"version":'; then
     echo ""
     echo "❌ package.json \"version\" change detected on branch '$BRANCH'."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,13 +1,7 @@
 # Step 0: Guard against package.json version bumps outside main
 # Version bumps must be committed as a dedicated release commit on main.
 BRANCH=$(git branch --show-current)
-# `git branch --show-current` prints NOTHING when HEAD is detached, so the empty string was
-# being read as "a branch that is not main". Any flow that stages a version change with a
-# detached HEAD — validating a merge in a throwaway worktree, an interactive rebase, a
-# bisect — was refused with `on branch ''`, naming a branch nobody chose.
-#
-# The intent is unchanged: a version bump must not ride along on a NAMED feature branch. A
-# detached HEAD is a validation or rebase context, not a path a person releases from.
+# `git branch --show-current` prints nothing on a detached HEAD, which must not read as "not main".
 if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && git diff --cached --name-only | grep -q "^package.json$"; then
   if git diff --cached package.json | grep -qE '^[+-][[:space:]]*"version":'; then
     echo ""


### PR DESCRIPTION
## The bug

`.husky/pre-commit` step 0 guards against version bumps outside `main`:

```sh
BRANCH=$(git branch --show-current)
if [ "$BRANCH" != "main" ] && git diff --cached --name-only | grep -q "^package.json$"; then
```

`git branch --show-current` prints **nothing** when HEAD is detached. The empty string is
therefore read as "a branch that is not main", and the guard refuses with:

```
❌ package.json "version" change detected on branch ''.
```

naming a branch nobody chose.

## When it bites

Any flow that stages a version change with a detached HEAD — validating a merge in a
throwaway worktree, an interactive rebase, a bisect.

We hit it merging the **v0.1.11** release. Our merge check squashes a PR into a detached
worktree of `main` and runs this hook against the result, so the guard objected to the
release commit's own version bump. A release was unmergeable through the very check it is
meant to satisfy, and the message pointed at a branch name that did not exist.

## The fix

One added test: `[ -n "$BRANCH" ]`.

The intent is unchanged — a version bump must not ride along on a **named** feature branch.
A detached HEAD is a validation or rebase context, not a path a person releases from, so it
is out of scope for the rule rather than the worst case of it.

## Verified

Four ways, in a throwaway repo with step 0 isolated:

| case | result | wanted |
|---|---|---|
| named feature branch + version bump | refused | refused — intent preserved |
| `main` + version bump | allowed | allowed |
| **detached HEAD + version bump** | **allowed** | allowed — this was the bug |
| detached, fix removed | refused | refused — the fix is load-bearing |

Happy to adjust the wording or add a test in whatever form you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version-change validation now applies only on named branches other than `main`.
  * Detached HEAD states are no longer incorrectly rejected during pre-commit checks.
  * Developers can now commit staged version updates in detached HEAD states without an unnecessary validation failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->