### PR TITLE
test(integration): cover the claude -> codex direction

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "snapshot:upstream": "node scripts/snapshot-upstream.mjs",
     "snapshot:model-drift": "node scripts/detect-model-drift.mjs",
     "snapshot:enum-drift": "node scripts/detect-enum-drift.mjs",
-    "test": "node --test tests/*.test.mjs tests/integration/codex-to-claude/*.test.mjs",
+    "test": "node --test tests/*.test.mjs tests/integration/codex-to-claude/*.test.mjs tests/integration/claude-to-codex/*.test.mjs",
     "test:manual:reset": "tests/integration/manual-codex-to-claude/scripts/reset.sh",
     "test:manual:run": "tests/integration/manual-codex-to-claude/scripts/run-cases.sh",
     "test:set-home": "tests/integration/manual-codex-to-claude/scripts/set-home-to-test-lab.sh",

--- a/tests/integration/claude-to-codex/agents.test.mjs
+++ b/tests/integration/claude-to-codex/agents.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { cleanupFixture, createIntegrationFixture, layClaudeHome } from "../helpers/fixture.mjs";
+import { runSync } from "../helpers/run-cli.mjs";
+import { diffTrees, formatTreeDiff, snapshotTree } from "../helpers/snapshot.mjs";
+
+function withFixture(scenario, body) {
+  const fixture = createIntegrationFixture({ scenario });
+  let kept = false;
+  try {
+    body(fixture);
+  } catch (error) {
+    if (process.env.KEEP_FIXTURE === "1") {
+      kept = true;
+      error.message = `${error.message}\n[fixture kept at ${fixture.root}]`;
+    }
+    throw error;
+  } finally {
+    if (!kept && process.env.KEEP_FIXTURE !== "1") {
+      cleanupFixture(fixture);
+    }
+  }
+}
+
+function applyAgents(fixture) {
+  return runSync({
+    home: fixture.home,
+    projectRoot: fixture.project,
+    args: [
+      "--scope",
+      "global",
+      "--include",
+      "agents",
+      "--from",
+      "claude",
+      "--to",
+      "codex",
+      "--apply",
+    ],
+  });
+}
+
+function assertClaudeSourceUnchanged(home, beforeSnapshot) {
+  const diff = diffTrees(snapshotTree(join(home, ".claude")), beforeSnapshot);
+  if (diff.missing.length > 0 || diff.extra.length > 0 || diff.changed.length > 0) {
+    assert.fail(`source tree mutated under .claude:\n${formatTreeDiff(diff)}`);
+  }
+}
+
+// the writer re-emits the markdown body verbatim, trailing newline included, so bytes cannot match the hand-written TOML fixture
+test("apply writes claude agent frontmatter into a codex agent TOML", () => {
+  withFixture("agents-reverse-apply-happy", (fixture) => {
+    const specs = [{ area: "agents", variant: "happy" }];
+    layClaudeHome(fixture.home, specs);
+    const beforeSnapshot = snapshotTree(join(fixture.home, ".claude"));
+
+    const result = applyAgents(fixture);
+    assert.equal(result.status, 0, `apply failed: ${result.output}`);
+
+    const toml = readFileSync(join(fixture.home, ".codex", "agents", "translate.toml"), "utf8");
+    assert.match(toml, /^name = "translate"$/m);
+    assert.match(
+      toml,
+      /^description = "Translates user text to the requested target language\."$/m
+    );
+    assert.match(toml, /^developer_instructions = ".*Translate the user input verbatim/m);
+
+    assertClaudeSourceUnchanged(fixture.home, beforeSnapshot);
+  });
+});
+
+test("second apply is idempotent", () => {
+  withFixture("agents-reverse-idempotent", (fixture) => {
+    const specs = [{ area: "agents", variant: "happy" }];
+    layClaudeHome(fixture.home, specs);
+
+    const first = applyAgents(fixture);
+    assert.equal(first.status, 0, `first apply failed: ${first.output}`);
+
+    const afterFirst = snapshotTree(join(fixture.home, ".codex"));
+
+    const second = applyAgents(fixture);
+    assert.equal(second.status, 0, `second apply failed: ${second.output}`);
+
+    const afterSecond = snapshotTree(join(fixture.home, ".codex"));
+    assert.equal(
+      afterSecond.size,
+      afterFirst.size,
+      "codex tree size changed between first and second apply"
+    );
+    for (const [path, entry] of afterFirst) {
+      const next = afterSecond.get(path);
+      assert.ok(next, `path ${path} disappeared on second apply`);
+      assert.equal(next.sha256, entry.sha256, `path ${path} content changed on second apply`);
+    }
+  });
+});

--- a/tests/integration/claude-to-codex/mcp.test.mjs
+++ b/tests/integration/claude-to-codex/mcp.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { cleanupFixture, createIntegrationFixture, layClaudeHome } from "../helpers/fixture.mjs";
+import { runSync } from "../helpers/run-cli.mjs";
+import { snapshotTree } from "../helpers/snapshot.mjs";
+
+function withFixture(scenario, body) {
+  const fixture = createIntegrationFixture({ scenario });
+  let kept = false;
+  try {
+    body(fixture);
+  } catch (error) {
+    if (process.env.KEEP_FIXTURE === "1") {
+      kept = true;
+      error.message = `${error.message}\n[fixture kept at ${fixture.root}]`;
+    }
+    throw error;
+  } finally {
+    if (!kept && process.env.KEEP_FIXTURE !== "1") {
+      cleanupFixture(fixture);
+    }
+  }
+}
+
+function applyMcp(fixture) {
+  return runSync({
+    home: fixture.home,
+    projectRoot: fixture.project,
+    args: ["--scope", "global", "--include", "mcp", "--from", "claude", "--to", "codex", "--apply"],
+  });
+}
+
+// the writer fences servers in ai-config-sync markers, so bytes cannot match the hand-written config.toml fixture
+test("mcpServers.notion becomes a managed [mcp_servers.notion] block", () => {
+  withFixture("mcp-reverse-apply-happy", (fixture) => {
+    const specs = [{ area: "mcp", variant: "happy" }];
+    layClaudeHome(fixture.home, specs);
+    const sourceBefore = readFileSync(join(fixture.home, ".claude.json"), "utf8");
+
+    const result = applyMcp(fixture);
+    assert.equal(result.status, 0, `apply failed: ${result.output}`);
+
+    const toml = readFileSync(join(fixture.home, ".codex", "config.toml"), "utf8");
+    assert.match(toml, /^# BEGIN ai-config-sync mcp-servers$/m);
+    assert.match(toml, /^# END ai-config-sync mcp-servers$/m);
+    assert.match(toml, /^\[mcp_servers\.notion\]$/m);
+    assert.match(toml, /^command = "npx"$/m);
+    assert.match(toml, /^args = \["-y","@notionhq\/notion-mcp-server"\]$/m);
+
+    assert.equal(
+      readFileSync(join(fixture.home, ".claude.json"), "utf8"),
+      sourceBefore,
+      "apply must not mutate the claude source ~/.claude.json"
+    );
+  });
+});
+
+test("second apply is idempotent", () => {
+  withFixture("mcp-reverse-idempotent", (fixture) => {
+    const specs = [{ area: "mcp", variant: "happy" }];
+    layClaudeHome(fixture.home, specs);
+
+    const first = applyMcp(fixture);
+    assert.equal(first.status, 0, `first apply failed: ${first.output}`);
+
+    const afterFirst = snapshotTree(join(fixture.home, ".codex"));
+
+    const second = applyMcp(fixture);
+    assert.equal(second.status, 0, `second apply failed: ${second.output}`);
+
+    const afterSecond = snapshotTree(join(fixture.home, ".codex"));
+    assert.equal(
+      afterSecond.size,
+      afterFirst.size,
+      "codex tree size changed between first and second apply"
+    );
+    for (const [path, entry] of afterFirst) {
+      const next = afterSecond.get(path);
+      assert.ok(next, `path ${path} disappeared on second apply`);
+      assert.equal(next.sha256, entry.sha256, `path ${path} content changed on second apply`);
+    }
+  });
+});

--- a/tests/integration/claude-to-codex/skills.test.mjs
+++ b/tests/integration/claude-to-codex/skills.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  cleanupFixture,
+  createIntegrationFixture,
+  layClaudeHome,
+  layCodexHome,
+} from "../helpers/fixture.mjs";
+import { assertGolden } from "../helpers/golden.mjs";
+import { runSync } from "../helpers/run-cli.mjs";
+import { diffTrees, formatTreeDiff, snapshotTree } from "../helpers/snapshot.mjs";
+
+const GOLDEN_IGNORE = [
+  ".ai-config-sync-manager/",
+  "backups/",
+  ".DS_Store",
+  ".claude/",
+  ".claude.json",
+];
+
+function withFixture(scenario, body) {
+  const fixture = createIntegrationFixture({ scenario });
+  let kept = false;
+  try {
+    body(fixture);
+  } catch (error) {
+    if (process.env.KEEP_FIXTURE === "1") {
+      kept = true;
+      error.message = `${error.message}\n[fixture kept at ${fixture.root}]`;
+    }
+    throw error;
+  } finally {
+    if (!kept && process.env.KEEP_FIXTURE !== "1") {
+      cleanupFixture(fixture);
+    }
+  }
+}
+
+function applySkills(fixture) {
+  return runSync({
+    home: fixture.home,
+    projectRoot: fixture.project,
+    args: [
+      "--scope",
+      "global",
+      "--include",
+      "skills",
+      "--from",
+      "claude",
+      "--to",
+      "codex",
+      "--apply",
+    ],
+  });
+}
+
+function assertClaudeSourceUnchanged(home, beforeSnapshot) {
+  const diff = diffTrees(snapshotTree(join(home, ".claude")), beforeSnapshot);
+  if (diff.missing.length > 0 || diff.extra.length > 0 || diff.changed.length > 0) {
+    assert.fail(`source tree mutated under .claude:\n${formatTreeDiff(diff)}`);
+  }
+}
+
+test("apply copies claude SKILL.md into .agents/skills intact (golden)", () => {
+  withFixture("skills-reverse-apply-happy", (fixture) => {
+    const specs = [{ area: "skills", variant: "happy" }];
+    layClaudeHome(fixture.home, specs);
+    const beforeSnapshot = snapshotTree(join(fixture.home, ".claude"));
+
+    const result = applySkills(fixture);
+    assert.equal(result.status, 0, `apply failed: ${result.output}`);
+
+    layCodexHome(fixture.expectedHome, specs);
+    assertGolden(fixture.home, fixture.expectedHome, { ignore: GOLDEN_IGNORE });
+    assertClaudeSourceUnchanged(fixture.home, beforeSnapshot);
+  });
+});
+
+test("second apply is idempotent", () => {
+  withFixture("skills-reverse-idempotent", (fixture) => {
+    const specs = [{ area: "skills", variant: "happy" }];
+    layClaudeHome(fixture.home, specs);
+
+    const first = applySkills(fixture);
+    assert.equal(first.status, 0, `first apply failed: ${first.output}`);
+
+    const afterFirst = snapshotTree(join(fixture.home, ".agents"));
+
+    const second = applySkills(fixture);
+    assert.equal(second.status, 0, `second apply failed: ${second.output}`);
+
+    const afterSecond = snapshotTree(join(fixture.home, ".agents"));
+    assert.equal(
+      afterSecond.size,
+      afterFirst.size,
+      "agents tree size changed between first and second apply"
+    );
+    for (const [path, entry] of afterFirst) {
+      const next = afterSecond.get(path);
+      assert.ok(next, `path ${path} disappeared on second apply`);
+      assert.equal(next.sha256, entry.sha256, `path ${path} content changed on second apply`);
+    }
+  });
+});

--- a/tests/integration/helpers/fixture.mjs
+++ b/tests/integration/helpers/fixture.mjs
@@ -35,6 +35,16 @@ export function layCodexHome(home, areaSpecs) {
   }
 }
 
+export function layClaudeHome(home, areaSpecs) {
+  for (const { area, variant } of areaSpecs) {
+    const src = join(fixturesRoot, area, variant, "expected-claude");
+    if (!existsSync(src)) {
+      throw new Error(`fixture missing: ${area}/${variant}/expected-claude`);
+    }
+    cpSync(src, home, { recursive: true, dereference: false, verbatimSymlinks: true });
+  }
+}
+
 export function layPreExistingClaude(home, areaSpecs) {
   for (const { area, variant } of areaSpecs) {
     const src = join(fixturesRoot, area, variant, "pre-claude");


### PR DESCRIPTION
`todo-plan.md` §1.1. The integration suite only ran `codex -> claude`, so a regression on the reverse path would not have been caught — which matters because §1.2 (the `bin/util/` extraction) is about to move code that both directions share.

## Reusing the existing fixtures

No new fixture data. The existing `expected-claude` directories are already valid Claude home trees, so they serve directly as the input for the reverse direction. One helper is added — `layClaudeHome`, modeled on `layCodexHome` including its throw-on-missing and `verbatimSymlinks`.

## Assertion style per area

Only skills can be compared byte for byte; the round trip was verified identical against `fixtures/areas/skills/happy/codex-home`. The other two cannot be, for reasons that are correct behavior rather than bugs:

| area | why not golden |
| --- | --- |
| agents | the writer re-emits the markdown body verbatim, trailing newline included, so it cannot match a hand-written TOML fixture |
| mcp | output is wrapped in `# BEGIN/END ai-config-sync` markers that a hand-written `config.toml` does not carry |

Both are asserted on fields instead. The agents trailing-newline divergence was checked over three full round trips and converges — it does not accumulate.

## Two things worth reviewing

**`package.json` is touched.** The `test` script lists integration directories by path, so without adding `tests/integration/claude-to-codex/*.test.mjs` the entire new suite would never run and the suite would have stayed green while covering nothing.

**`assertSourceUnchanged` is not used.** It hardcodes `[".codex", ".agents/skills"]` (`tests/integration/helpers/snapshot.mjs:120`), which is the *target* side in this direction — calling it would have asserted that the target never changed. Each file uses a local `.claude`-side check built from the exported `snapshotTree`/`diffTrees` instead, matching the existing convention of per-file local helpers (`withFixture` and `walkFiles` are already duplicated across all seven `codex-to-claude` files).

## Scope

Happy path only. Deletion propagation and the overwrite/merge matrix stay in §1.7.

`commands` is listed in §1.1's checklist but is **not** covered here: the area appears only in the `ConfigArea` typedef (`bin/ai-config-sync.mjs:52`) and has no sync implementation — both global and project scope return "No sync operations planned". It needs the feature built before a test can exist, and §1.7 already carries it as a separate item.

## Verification

- `npm test` — 419 tests, 417 pass, 0 fail, 2 skipped (was 413/411)
- New files alone — 6 tests, 6 pass
- **Deliberate-break check**, one round per area, `bin/` restored to an empty diff after each:

| broken | test that went red |
| --- | --- |
| `serializeCodexAgentFile` → `return ""` | agents happy |
| `renderCodexMcpServers` → `return ""` | mcp happy |
| `copySkillTreeWithMappings` → `return` | skills happy |

Each break took down exactly its own area's happy test and nothing else.

One honest limitation: the three idempotency tests stayed green under every break, because a writer that emits nothing is trivially idempotent. They are load-bearing only against a writer that does not converge, which is what they are for — they are not break detectors.
